### PR TITLE
EOPatch input

### DIFF
--- a/configs/fcn_example.json
+++ b/configs/fcn_example.json
@@ -4,7 +4,7 @@
         "config": {
             "learning_rate": 0.0001,
             "n_layers": 3,
-            "n_classes": 2,
+            "n_classes": 3,
             "keep_prob": 0.8,
             "features_root": 32,
             "conv_size": 3,
@@ -26,9 +26,9 @@
             "input_config":{
                 "classname": "eoflow.input.random.RandomSegmentationInput",
                 "config": {
-                    "input_shape": [148, 148, 13],
-                    "output_shape": [60, 60],
-                    "num_classes": 2,
+                    "input_shape": [128, 128, 13],
+                    "output_shape": [128, 128],
+                    "num_classes": 3,
                     "batch_size": 2,
                     "batches_per_epoch": 1000
                 }

--- a/configs/rfcn_example.json
+++ b/configs/rfcn_example.json
@@ -4,7 +4,7 @@
         "config": {
             "learning_rate": 0.0001,
             "n_layers": 3,
-            "n_classes": 2,
+            "n_classes": 3,
             "keep_prob": 0.8,
             "features_root": 32,
             "conv_size": 3,
@@ -26,9 +26,9 @@
             "input_config":{
                 "classname": "eoflow.input.random.RandomSegmentationInput",
                 "config": {
-                    "input_shape": [10, 150, 150, 13],
-                    "output_shape": [76, 76],
-                    "num_classes": 2,
+                    "input_shape": [10, 128, 128, 13],
+                    "output_shape": [128, 128],
+                    "num_classes": 3,
                     "batch_size": 1,
                     "batches_per_epoch": 1000
                 }

--- a/configs/tfcn_example.json
+++ b/configs/tfcn_example.json
@@ -31,7 +31,7 @@
                 "classname": "eoflow.input.random.RandomSegmentationInput",
                 "config": {
                     "input_shape": [10, 150, 150, 13],
-                    "output_shape": [76, 76],
+                    "output_shape": [150, 150],
                     "num_classes": 2,
                     "batch_size": 1,
                     "batches_per_epoch": 1000

--- a/configs/tfcn_example.json
+++ b/configs/tfcn_example.json
@@ -30,8 +30,8 @@
             "input_config":{
                 "classname": "eoflow.input.random.RandomSegmentationInput",
                 "config": {
-                    "input_shape": [10, 150, 150, 13],
-                    "output_shape": [150, 150],
+                    "input_shape": [10, 128, 128, 13],
+                    "output_shape": [128, 128],
                     "num_classes": 2,
                     "batch_size": 1,
                     "batches_per_epoch": 1000

--- a/configs/tfcn_example_real.json
+++ b/configs/tfcn_example_real.json
@@ -19,7 +19,8 @@
             "pool_time": false,
             "single_encoding_conv": true,
             "conv_size_reduce": 3,
-            "loss": "cross-entropy"
+            "loss": "cross-entropy",
+            "image_summaries": true
         }
     },
     "task": {

--- a/configs/tfcn_example_real.json
+++ b/configs/tfcn_example_real.json
@@ -4,7 +4,7 @@
         "config": {
             "learning_rate": 0.0001,
             "n_layers": 3,
-            "n_classes": 2,
+            "n_classes": 10,
             "keep_prob": 0.8,
             "features_root": 16,
             "conv_size": 3,
@@ -39,14 +39,14 @@
                     "labels_feature_name": "LULC_RABA",
                     "labels_feature_axis": [0,1],
                     "labels_feature_shape": [-1, -1, 1],
-                    "patch_size": [150, 150],
+                    "patch_size": [128, 128],
                     "interleave_size": 3,
-                    "batch_size": 10,
+                    "batch_size": 5,
                     "num_classes": 10
                 }
             },
             "save_steps": 100,
-            "summary_steps": 50,
+            "summary_steps": 10,
             "progress_steps": 1
         }
     }

--- a/configs/tfcn_example_real.json
+++ b/configs/tfcn_example_real.json
@@ -26,10 +26,10 @@
     "task": {
         "classname": "eoflow.tasks.TrainTask",
         "config": {
-            "num_epochs": 2,
+            "num_epochs": 5,
             "output_directory": "./temp/tfcn_svn_lulc",
             "input_config":{
-                "classname": "eoflow.input.eopatch.EOPatchInput",
+                "classname": "eoflow.input.eopatch.EOPatchInputExample",
                 "config": {
                     "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/train",
                     "input_feature_type": "data",
@@ -43,7 +43,9 @@
                     "patch_size": [128, 128],
                     "interleave_size": 3,
                     "batch_size": 5,
-                    "num_classes": 10
+                    "num_classes": 10,
+                    "cache_file": "./temp/tfcn_svn_lulc/dataset/cache",
+                    "num_subpatches": 5
                 }
             },
             "save_steps": 100,

--- a/configs/tfcn_example_real.json
+++ b/configs/tfcn_example_real.json
@@ -1,0 +1,54 @@
+{
+    "model": {
+        "classname": "eoflow.models.TFCNModel",
+        "config": {
+            "learning_rate": 0.0001,
+            "n_layers": 3,
+            "n_classes": 2,
+            "keep_prob": 0.8,
+            "features_root": 16,
+            "conv_size": 3,
+            "conv_stride": 1,
+            "deconv_size": 2,
+            "add_dropout": true,
+            "add_batch_norm": false,
+            "bias_init": 0.0,
+            "padding": "VALID",
+            "pool_size": 2,
+            "pool_stride": 2,
+            "pool_time": false,
+            "single_encoding_conv": true,
+            "conv_size_reduce": 3,
+            "loss": "cross-entropy"
+        }
+    },
+    "task": {
+        "classname": "eoflow.tasks.TrainTask",
+        "config": {
+            "num_epochs": 2,
+            "output_directory": "./temp/tfcn_svn_lulc",
+            "input_config":{
+                "classname": "eoflow.input.eopatch.EOPatchInput",
+                "config": {
+                    "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/train",
+                    "input_feature_type": "data",
+                    "input_feature_name": "FEATURES",
+                    "input_feature_axis": [1,2],
+                    "input_feature_shape": [23, -1, -1, 9],
+                    "labels_feature_type": "mask_timeless",
+                    "labels_feature_name": "LULC_RABA",
+                    "labels_feature_axis": [0,1],
+                    "labels_feature_shape": [-1, -1, 1],
+                    "patch_size": [150, 150],
+                    "interleave_size": 3,
+                    "batch_size": 10,
+                    "num_classes": 10
+                }
+            },
+            "save_steps": 100,
+            "summary_steps": 50,
+            "progress_steps": 1
+        }
+    }
+  }
+  

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -132,6 +132,12 @@ class BaseModel(Configurable):
             checkpoint_path = os.path.join(checkpoint_dir, 'model.ckpt')
             saver = tf.train.Saver()
 
+            # Restore latest checkpoint if it exits
+            checkpoint_file = tf.train.latest_checkpoint(checkpoint_dir)
+            if checkpoint_file is not None:
+                print("Restoring checkpoint: %s" % checkpoint_file)
+                saver.restore(sess, checkpoint_file)
+
             # Create summary writer
             create_dirs([checkpoint_dir])
             summary_writer = tf.summary.FileWriter(output_directory, sess.graph)

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -19,28 +19,7 @@ class BaseModel(Configurable):
 
         self.summaries = []
 
-        # init the epoch counter
-        self.init_cur_epoch()
-
-    # save function that saves the checkpoint in the path defined in the config file
-    def save(self, sess):
-        self.saver.save(sess, self.config.checkpoint_dir, self.global_step_tensor)
-        logging.info("Model saved")
-
-    # load latest checkpoint from the experiment path defined in the config file
-    def load(self, sess):
-        latest_checkpoint = tf.train.latest_checkpoint(self.config.checkpoint_dir)
-        if latest_checkpoint:
-            self.saver.restore(sess, latest_checkpoint)
-            logging.info("Model loaded from checkpoint {}".format(latest_checkpoint))
-
-    # just initialize a tensorflow variable to use it as epoch counter
-    def init_cur_epoch(self):
-        with tf.variable_scope('cur_epoch'):
-            self.cur_epoch_tensor = tf.Variable(0, trainable=False, name='cur_epoch')
-            self.increment_cur_epoch_tensor = tf.assign(self.cur_epoch_tensor, self.cur_epoch_tensor + 1)
-
-    # just initialize a tensorflow variable to use it as global step counter
+    # Initialize a tensorflow variable to use it as global step counter
     def init_global_step(self):
         # DON'T forget to add the global step tensor to the tensorflow trainer
         with tf.variable_scope('global_step'):
@@ -93,11 +72,6 @@ class BaseModel(Configurable):
             return tf.summary.merge(self.summaries)
         else:
             return tf.constant("")
-
-    def init_saver(self):
-        # just copy the following line in your child class
-        # self.saver = tf.train.Saver(max_to_keep=self.config.max_to_keep)
-        raise NotImplementedError
 
     def build_model(self, features, labels, mode):
         """Builds the model for the provided input features and labels.

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -112,6 +112,24 @@ class BaseModel(Configurable):
         raise NotImplementedError
 
     def train(self, dataset_fn, num_epochs, output_directory, save_steps=100, summary_steps=10, progress_steps=10):
+        """ Trains the model on a given dataset. Takes care of saving the model and recording summaries.
+
+        :param dataset_fn: A function that builds and returns a tf.data.Dataset containing the input training data.
+            The dataset must be of shape (features, labels) where features and labels contain the data
+            in the shape required by the model.
+        :type dataset_fn: function
+        :param num_epochs: Number of epochs.
+        :type num_epochs: int
+        :param output_directory: Output directory, where the model checkpoints and summaries are saved.
+        :type output_directory: str
+        :param save_steps: Number of steps between saving model checkpoints.
+        :type save_steps: int
+        :param summary_steps: Number of steps between recodring summaries.
+        :type summary_steps: int
+        :param progress_steps: Number of steps between outputing progress to stdout.
+        :type progress_steps: int
+        """
+        
         # Clear graph
         tf.reset_default_graph()
 

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -4,6 +4,7 @@ import os
 from enum import Enum
 
 from . import Configurable
+from ..utils import create_dirs
 
 class ModelMode(Enum):
     TRAIN = 1
@@ -18,8 +19,6 @@ class BaseModel(Configurable):
 
         self.summaries = []
 
-        # init the global step
-        self.init_global_step()
         # init the epoch counter
         self.init_cur_epoch()
 
@@ -102,7 +101,7 @@ class BaseModel(Configurable):
 
     def build_model(self, features, labels, mode):
         """Builds the model for the provided input features and labels.
-        
+
         :param features: Input features tensor. Can be a single tensor or a dict of tensors.
         :type features: tf.tensor | dict(str, tf.tensor)
         :param labels: Labels tensor. Can be a single tensor or a dict of tensors.
@@ -111,3 +110,61 @@ class BaseModel(Configurable):
         :type mode: eoflow.base.ModelMode
         """
         raise NotImplementedError
+
+    def train(self, dataset_fn, num_epochs, output_directory, save_steps=100, summary_steps=10, progress_steps=10):
+        # Clear graph
+        tf.reset_default_graph()
+
+        with tf.Session() as sess:
+            # Build the dataset
+            dataset = dataset_fn()
+            iterator = dataset.make_initializable_iterator()
+            features, labels = iterator.get_next()
+
+            # Build model
+            self.init_global_step()
+            train_op, loss_op, summaries_op = self.build_model(features, labels, ModelMode.TRAIN)
+
+            # Create saver
+            step_tensor = self.global_step_tensor
+            checkpoint_dir = os.path.join(output_directory, 'checkpoints')
+            create_dirs([checkpoint_dir])
+            checkpoint_path = os.path.join(checkpoint_dir, 'model.ckpt')
+            saver = tf.train.Saver()
+
+            # Create summary writer
+            create_dirs([checkpoint_dir])
+            summary_writer = tf.summary.FileWriter(output_directory, sess.graph)
+
+            # Initialize variables
+            initializer = tf.global_variables_initializer()
+            sess.run(initializer)
+
+            # Train
+            training_step = 1
+            for e in range(num_epochs):
+                sess.run(iterator.initializer)
+                print("Epoch %d/%d" % (e+1, num_epochs))
+
+                while True:
+                    try:
+                        # Compute and record summaries every summary_steps
+                        if training_step % summary_steps == 0:
+                            _, loss, step, summaries = sess.run([train_op, loss_op, step_tensor, summaries_op])
+
+                            summary_writer.add_summary(summaries, global_step=step)
+                        else:
+                            _, loss, step = sess.run([train_op, loss_op, step_tensor])
+
+                        # Show progress
+                        if training_step % progress_steps == 0:
+                            print("Step %d: %f" % (step, loss))
+
+                        # Model saving
+                        if training_step % save_steps == 0:
+                            print("Saving checkpoint at step %d." % step)
+                            saver.save(sess, checkpoint_path, global_step=step)
+
+                        training_step += 1
+                    except tf.errors.OutOfRangeError:
+                        break

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -141,30 +141,39 @@ class BaseModel(Configurable):
             sess.run(initializer)
 
             # Train
-            training_step = 1
-            for e in range(num_epochs):
-                sess.run(iterator.initializer)
-                print("Epoch %d/%d" % (e+1, num_epochs))
+            try:
+                training_step = 1
+                for e in range(num_epochs):
+                    sess.run(iterator.initializer)
+                    print("Epoch %d/%d" % (e+1, num_epochs))
 
-                while True:
-                    try:
-                        # Compute and record summaries every summary_steps
-                        if training_step % summary_steps == 0:
-                            _, loss, step, summaries = sess.run([train_op, loss_op, step_tensor, summaries_op])
+                    while True:
+                        try:
+                            # Compute and record summaries every summary_steps
+                            if training_step % summary_steps == 0:
+                                _, loss, step, summaries = sess.run([train_op, loss_op, step_tensor, summaries_op])
 
-                            summary_writer.add_summary(summaries, global_step=step)
-                        else:
-                            _, loss, step = sess.run([train_op, loss_op, step_tensor])
+                                summary_writer.add_summary(summaries, global_step=step)
+                            else:
+                                _, loss, step = sess.run([train_op, loss_op, step_tensor])
 
-                        # Show progress
-                        if training_step % progress_steps == 0:
-                            print("Step %d: %f" % (step, loss))
+                            # Show progress
+                            if training_step % progress_steps == 0:
+                                print("Step %d: %f" % (step, loss))
 
-                        # Model saving
-                        if training_step % save_steps == 0:
-                            print("Saving checkpoint at step %d." % step)
-                            saver.save(sess, checkpoint_path, global_step=step)
+                            # Model saving
+                            if training_step % save_steps == 0:
+                                print("Saving checkpoint at step %d." % step)
+                                saver.save(sess, checkpoint_path, global_step=step)
 
-                        training_step += 1
-                    except tf.errors.OutOfRangeError:
-                        break
+                            training_step += 1
+                        except tf.errors.OutOfRangeError:
+                            break
+
+            # Catch user interrupt
+            except KeyboardInterrupt:
+                print("Training interrupted by user.")
+
+            # Save at the end of training
+            print("Saving checkpoint at step %d." % step)
+            saver.save(sess, checkpoint_path, global_step=step)

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -10,7 +10,7 @@ from .operations import extract_subpatches, augment_data
 
 _valid_types = [t.value for t in FeatureType]
 
-def eopatch_dataset(data_dir, features_data):
+def eopatch_dataset(data_dir, features_data, fill_na=None):
     """ Reads a features and labels from a single EOPatch.
 
     :param data_dir: Root directory containing eopatches in the dataset
@@ -18,6 +18,8 @@ def eopatch_dataset(data_dir, features_data):
     :param features_data: List of tuples containing data about features to extract.
         Tuple structure: (feature_type, feature_name, out_feature_name, feature_dtype, feature_shape)
     :type features_data: (str, str, str, np.dtype, tuple)
+    :param fill_na: Value with wich to replace nan values. No replacement is done if None.
+    :type fill_na: int
     """
 
     file_pattern = os.path.join(data_dir, '*')
@@ -35,6 +37,10 @@ def eopatch_dataset(data_dir, features_data):
             data = []
             for feat_type, feat_name, out_name, dtype, shape in features_data:
                 arr = patch[feat_type][feat_name].astype(dtype)
+
+                if fill_na is not None:
+                    arr[np.isnan(arr)] = fill_na
+
                 data.append(arr)
 
             return data
@@ -90,7 +96,7 @@ class EOPatchInput(BaseInput):
             (cfg.labels_feature_type, cfg.labels_feature_name, 'labels', np.int64, self._parse_shape(cfg.labels_feature_shape))
         ]
 
-        dataset = eopatch_dataset(self.config.data_dir, features_data)
+        dataset = eopatch_dataset(self.config.data_dir, features_data, fill_na=-2)
 
         extract_fn = extract_subpatches(
             self.config.patch_size,

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -1,0 +1,51 @@
+import os
+import numpy as np
+import tensorflow as tf
+from marshmallow import fields, Schema
+from marshmallow.validate import OneOf
+from eolearn.core import EOPatch, FeatureType
+
+from ..base import BaseInput
+
+_valid_types = [t.value for t in FeatureType]
+
+class EOPatchInput(BaseInput):
+    """ Class to create random batches for classification tasks. """
+
+    class _Schema(Schema):
+        data_dir = fields.String(description="The directory containing EOPatches.", required=True)
+
+        input_feature_type = fields.String(description="Feature type of the input feature.", required=True, validate=OneOf(_valid_types))
+        input_feature_name = fields.String(description="Name of the input feature.", required=True)
+
+        labels_feature_type = fields.String(description="Feature type of the labels feature.", required=True, validate=OneOf(_valid_types))
+        labels_feature_name = fields.String(description="Name of the labels feature.", required=True)
+
+        batch_size = fields.Int(description="Number of examples in a batch.", required=True, example=20)
+
+    def _read_eopatch(self, path):
+        """ Reads a features and labels from a single EOPatch. """
+
+        def _func(path):
+            path = path.decode('utf-8')
+            features = [(self.config.input_feature_type, self.config.input_feature_name),
+                        (self.config.labels_feature_type, self.config.labels_feature_name)]
+            patch = EOPatch.load(path, features=features)
+
+            input_data = patch[self.config.input_feature_type][self.config.input_feature_name].astype(np.float32)
+            labels_data = patch[self.config.labels_feature_type][self.config.labels_feature_name].astype(np.int64)
+
+            return input_data, labels_data
+
+        features, labels = tf.py_func(_func, [path], (tf.float32, tf.int64))
+
+        return features, labels
+
+    def get_dataset(self):
+        file_pattern = os.path.join(self.config.data_dir, '*')
+        dataset = tf.data.Dataset.list_files(file_pattern)
+
+        dataset = dataset.map(self._read_eopatch)
+
+        return dataset
+

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -9,6 +9,138 @@ from ..base import BaseInput
 
 _valid_types = [t.value for t in FeatureType]
 
+def extract_patches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
+    """ Extract patches from EOPatch dataset. """
+
+    patch_w,patch_h = patch_size
+    def _fn(data):
+        feat_name_ref, axis_ref = spatial_features_and_axis[0]
+        ay_ref, ax_ref = axis_ref
+        # Get random coordinates
+        def _py_get_random(image):
+            x_space = image.shape[ax_ref]-patch_w
+            if x_space > 0:
+                x_rand = np.random.randint(x_space, size=num_random_samples, dtype=np.int64)
+            else:
+                x_rand = np.zeros(num_random_samples, np.int64)
+
+            y_space = image.shape[ay_ref]-patch_h 
+            if y_space > 0:
+                y_rand = np.random.randint(y_space, size=num_random_samples, dtype=np.int64)
+            else:
+                y_rand = np.zeros(num_random_samples, np.int64)
+
+            return x_rand, y_rand
+
+        # Get coordinates on a grid
+        def _py_get_gridded(image):
+
+            # alpha is overlaping ratio (w.r.t. patch size)
+            alpha = grid_overlap
+
+            img_height = image.shape[ay_ref]
+            img_width = image.shape[ax_ref]
+
+            # number of patches in x and y direction
+            nx = int(np.ceil((img_width - alpha * patch_w) / (patch_w * (1 - alpha))))
+            ny = int(np.ceil((img_height - alpha * patch_h) / (patch_h * (1 - alpha))))
+
+            # total number of patches
+            N = nx * ny
+            # allocate output vectors (top-left patch coordinates)
+            tl_x = np.zeros(N, dtype=np.int64)
+            tl_y = np.zeros(N, dtype=np.int64)
+
+            # calculate actual x and y coordinates
+            for yi in range(ny):
+                if yi == 0:
+                    # the highest patch has x0 = 0
+                    y_ = 0
+                elif yi == ny - 1:
+                    # the lowest patch has y0 = H - patch_h
+                    y_ = img_height - patch_h
+                else:
+                    # calculate top-left y coordinate and take into account overlaping, too
+                    y_ = np.round(yi * patch_h - yi * alpha * patch_h)
+
+                for xi in range(nx):
+                    if xi == 0:
+                        # the left-most patch has x0 = 0
+                        x_ = 0
+                    elif xi == nx - 1:
+                        # the right-most patch has x0 = W - patch_w
+                        x_ = img_width - patch_w
+                    else:
+                        # calculate top-left x coordinate and take into account overlaping, too
+                        x_ = np.round(xi * patch_w - xi * alpha * patch_w)
+
+                    id = yi * nx + xi
+                    tl_x[id] = np.int64(x_)
+                    tl_y[id] = np.int64(y_)
+
+            return tl_x, tl_y
+
+        if random_sampling:
+            x_samp, y_samp = tf.py_func(_py_get_random, [data[feat_name_ref]], [tf.int64, tf.int64])
+        else:
+            x_samp, y_samp = tf.py_func(_py_get_gridded, [data[feat_name_ref]], [tf.int64, tf.int64])
+
+        
+        def _py_get_patches(axis):
+            ay, ax = axis
+            # Extract patches for given coordinates
+            def _func(image, x_samp, y_samp):
+                patches = []
+
+                # Pad if necessary
+                x_pad = max(0, patch_w - image.shape[ax])
+                y_pad = max(0, patch_h - image.shape[ay])
+
+                if x_pad > 0 or y_pad > 0:
+                    print("Padding...")
+                    pad_x1 = x_pad//2
+                    pad_x2 = x_pad - pad_x1
+                    pad_y1 = y_pad//2
+                    pad_y2 = y_pad - pad_y1
+
+                    padding = [(0,0) for _ in range(image.ndim)]
+                    padding[ax] = (pad_x1,pad_x2)
+                    padding[ay] = (pad_y1,pad_y2)
+                    image = np.pad(image, padding, 'constant')
+                
+                # Extract patches
+                print("TEEEEEEEEST", x_samp)
+                for x, y in zip(x_samp, y_samp):
+                    # Slice on specified axis
+                    slicing = [slice(None) for _ in range(image.ndim)]
+                    slicing[ax] = slice(x, x+patch_w)
+                    slicing[ay] = slice(y, y+patch_h)
+
+                    patch = image[slicing]
+                    patches.append(patch)
+                return np.stack(patches)
+
+            return _func
+
+        data_out = {}
+        # TODO: repeat the rest of the data
+        for feat_name, axis in spatial_features_and_axis:
+            ay, ax = axis
+            shape = data[feat_name].shape.as_list()
+            patches = tf.py_func(_py_get_patches(axis), [data[feat_name], x_samp, y_samp], data[feat_name].dtype)
+            
+            # Update shape information
+            shape[ax] = patch_w
+            shape[ay] = patch_h
+            shape = [None] + shape
+            patches.set_shape(shape)
+
+            data_out[feat_name] = patches
+
+        return tf.data.Dataset.from_tensor_slices(data_out)
+
+    return _fn
+
 class EOPatchInput(BaseInput):
     """ Class to create random batches for classification tasks. """
 
@@ -17,9 +149,15 @@ class EOPatchInput(BaseInput):
 
         input_feature_type = fields.String(description="Feature type of the input feature.", required=True, validate=OneOf(_valid_types))
         input_feature_name = fields.String(description="Name of the input feature.", required=True)
+        input_feature_axis = fields.List(fields.Int, description="Height and width axis for the input features", required=True, example=[1,2])
+        input_feature_ndims = fields.Int(description="Number of dimensions for the input features", required=True, example=4)
 
         labels_feature_type = fields.String(description="Feature type of the labels feature.", required=True, validate=OneOf(_valid_types))
         labels_feature_name = fields.String(description="Name of the labels feature.", required=True)
+        labels_feature_axis = fields.List(fields.Int, description="Height and width axis for the labels", required=True, example=[1,2])
+        labels_feature_ndims = fields.Int(description="Number of dimensions for the labels", required=True, example=3)
+
+        patch_size = fields.List(fields.Int, description="Width and height of extracted patches.", required=True, example=[1,2])
 
         batch_size = fields.Int(description="Number of examples in a batch.", required=True, example=20)
 
@@ -39,13 +177,27 @@ class EOPatchInput(BaseInput):
 
         features, labels = tf.py_func(_func, [path], (tf.float32, tf.int64))
 
-        return features, labels
+        features.set_shape((None,)*self.config.input_feature_ndims)
+        labels.set_shape((None,)*self.config.labels_feature_ndims)
+
+        data = {
+            'features': features,
+            'labels': labels
+        }
+        return data
 
     def get_dataset(self):
         file_pattern = os.path.join(self.config.data_dir, '*')
         dataset = tf.data.Dataset.list_files(file_pattern)
 
         dataset = dataset.map(self._read_eopatch)
+
+        extract_fn = extract_patches(
+            self.config.patch_size,
+            [('features', self.config.input_feature_axis),
+             ('labels', self.config.labels_feature_axis)],
+        )
+        dataset = dataset.flat_map(extract_fn)
 
         return dataset
 

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -6,140 +6,53 @@ from marshmallow.validate import OneOf
 from eolearn.core import EOPatch, FeatureType
 
 from ..base import BaseInput
+from .operations import extract_subpatches
 
 _valid_types = [t.value for t in FeatureType]
 
-def extract_patches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
-    """ Extract patches from EOPatch dataset. """
+def eopatch_dataset(data_dir, features_data):
+        """ Reads a features and labels from a single EOPatch.
 
-    patch_w,patch_h = patch_size
-    def _fn(data):
-        feat_name_ref, axis_ref = spatial_features_and_axis[0]
-        ay_ref, ax_ref = axis_ref
-        # Get random coordinates
-        def _py_get_random(image):
-            x_space = image.shape[ax_ref]-patch_w
-            if x_space > 0:
-                x_rand = np.random.randint(x_space, size=num_random_samples, dtype=np.int64)
-            else:
-                x_rand = np.zeros(num_random_samples, np.int64)
+        :param data_dir: Root directory containing eopatches in the dataset
+        :type data_dir: str
+        :param features_data: List of tuples containing data about features to extract.
+            Tuple structure: (feature_type, feature_name, out_feature_name, feature_dtype, feature_ndims)
+        :type features_data: (str, str, str, np.dtype, int)
+        """
 
-            y_space = image.shape[ay_ref]-patch_h 
-            if y_space > 0:
-                y_rand = np.random.randint(y_space, size=num_random_samples, dtype=np.int64)
-            else:
-                y_rand = np.zeros(num_random_samples, np.int64)
+        file_pattern = os.path.join(data_dir, '*')
+        dataset = tf.data.Dataset.list_files(file_pattern)
 
-            return x_rand, y_rand
+        def _read_patch(path):
+            """ TF op for reading an eopatch at a given path. """
+            def _func(path):
+                path = path.decode('utf-8')
 
-        # Get coordinates on a grid
-        def _py_get_gridded(image):
+                # Load only relevant features
+                features = [(data[0], data[1]) for data in features_data]
+                patch = EOPatch.load(path, features=features)
 
-            # alpha is overlaping ratio (w.r.t. patch size)
-            alpha = grid_overlap
+                data = []
+                for feat_type, feat_name, out_name, dtype, ndims in features_data:
+                    arr = patch[feat_type][feat_name].astype(dtype)
+                    data.append(arr)
 
-            img_height = image.shape[ay_ref]
-            img_width = image.shape[ax_ref]
+                return data
 
-            # number of patches in x and y direction
-            nx = int(np.ceil((img_width - alpha * patch_w) / (patch_w * (1 - alpha))))
-            ny = int(np.ceil((img_height - alpha * patch_h) / (patch_h * (1 - alpha))))
+            out_types = [tf.as_dtype(data[3]) for data in features_data]
+            data = tf.py_func(_func, [path], out_types)
 
-            # total number of patches
-            N = nx * ny
-            # allocate output vectors (top-left patch coordinates)
-            tl_x = np.zeros(N, dtype=np.int64)
-            tl_y = np.zeros(N, dtype=np.int64)
+            out_data = {}
+            for f_data, feature in zip(features_data, data):
+                feat_type, feat_name, out_name, dtype, ndims = f_data
+                feature.set_shape((None,) * ndims)
+                out_data[out_name] = feature
 
-            # calculate actual x and y coordinates
-            for yi in range(ny):
-                if yi == 0:
-                    # the highest patch has x0 = 0
-                    y_ = 0
-                elif yi == ny - 1:
-                    # the lowest patch has y0 = H - patch_h
-                    y_ = img_height - patch_h
-                else:
-                    # calculate top-left y coordinate and take into account overlaping, too
-                    y_ = np.round(yi * patch_h - yi * alpha * patch_h)
+            return out_data
 
-                for xi in range(nx):
-                    if xi == 0:
-                        # the left-most patch has x0 = 0
-                        x_ = 0
-                    elif xi == nx - 1:
-                        # the right-most patch has x0 = W - patch_w
-                        x_ = img_width - patch_w
-                    else:
-                        # calculate top-left x coordinate and take into account overlaping, too
-                        x_ = np.round(xi * patch_w - xi * alpha * patch_w)
+        dataset = dataset.map(_read_patch)
+        return dataset
 
-                    id = yi * nx + xi
-                    tl_x[id] = np.int64(x_)
-                    tl_y[id] = np.int64(y_)
-
-            return tl_x, tl_y
-
-        if random_sampling:
-            x_samp, y_samp = tf.py_func(_py_get_random, [data[feat_name_ref]], [tf.int64, tf.int64])
-        else:
-            x_samp, y_samp = tf.py_func(_py_get_gridded, [data[feat_name_ref]], [tf.int64, tf.int64])
-
-        
-        def _py_get_patches(axis):
-            ay, ax = axis
-            # Extract patches for given coordinates
-            def _func(image, x_samp, y_samp):
-                patches = []
-
-                # Pad if necessary
-                x_pad = max(0, patch_w - image.shape[ax])
-                y_pad = max(0, patch_h - image.shape[ay])
-
-                if x_pad > 0 or y_pad > 0:
-                    print("Padding...")
-                    pad_x1 = x_pad//2
-                    pad_x2 = x_pad - pad_x1
-                    pad_y1 = y_pad//2
-                    pad_y2 = y_pad - pad_y1
-
-                    padding = [(0,0) for _ in range(image.ndim)]
-                    padding[ax] = (pad_x1,pad_x2)
-                    padding[ay] = (pad_y1,pad_y2)
-                    image = np.pad(image, padding, 'constant')
-                
-                # Extract patches
-                print("TEEEEEEEEST", x_samp)
-                for x, y in zip(x_samp, y_samp):
-                    # Slice on specified axis
-                    slicing = [slice(None) for _ in range(image.ndim)]
-                    slicing[ax] = slice(x, x+patch_w)
-                    slicing[ay] = slice(y, y+patch_h)
-
-                    patch = image[slicing]
-                    patches.append(patch)
-                return np.stack(patches)
-
-            return _func
-
-        data_out = {}
-        # TODO: repeat the rest of the data
-        for feat_name, axis in spatial_features_and_axis:
-            ay, ax = axis
-            shape = data[feat_name].shape.as_list()
-            patches = tf.py_func(_py_get_patches(axis), [data[feat_name], x_samp, y_samp], data[feat_name].dtype)
-            
-            # Update shape information
-            shape[ax] = patch_w
-            shape[ay] = patch_h
-            shape = [None] + shape
-            patches.set_shape(shape)
-
-            data_out[feat_name] = patches
-
-        return tf.data.Dataset.from_tensor_slices(data_out)
-
-    return _fn
 
 class EOPatchInput(BaseInput):
     """ Class to create random batches for classification tasks. """
@@ -159,45 +72,26 @@ class EOPatchInput(BaseInput):
 
         patch_size = fields.List(fields.Int, description="Width and height of extracted patches.", required=True, example=[1,2])
 
+        interleave_size = fields.Int(description="Number of eopatches to interleave the subpatches from.", required=True, example=5)
         batch_size = fields.Int(description="Number of examples in a batch.", required=True, example=20)
 
-    def _read_eopatch(self, path):
-        """ Reads a features and labels from a single EOPatch. """
-
-        def _func(path):
-            path = path.decode('utf-8')
-            features = [(self.config.input_feature_type, self.config.input_feature_name),
-                        (self.config.labels_feature_type, self.config.labels_feature_name)]
-            patch = EOPatch.load(path, features=features)
-
-            input_data = patch[self.config.input_feature_type][self.config.input_feature_name].astype(np.float32)
-            labels_data = patch[self.config.labels_feature_type][self.config.labels_feature_name].astype(np.int64)
-
-            return input_data, labels_data
-
-        features, labels = tf.py_func(_func, [path], (tf.float32, tf.int64))
-
-        features.set_shape((None,)*self.config.input_feature_ndims)
-        labels.set_shape((None,)*self.config.labels_feature_ndims)
-
-        data = {
-            'features': features,
-            'labels': labels
-        }
-        return data
-
     def get_dataset(self):
-        file_pattern = os.path.join(self.config.data_dir, '*')
-        dataset = tf.data.Dataset.list_files(file_pattern)
+        cfg = self.config
+        features_data = [
+            (cfg.input_feature_type, cfg.input_feature_name, 'features', np.float32, cfg.input_feature_ndims),
+            (cfg.labels_feature_type, cfg.labels_feature_name, 'labels', np.int64, cfg.labels_feature_ndims)
+        ]
 
-        dataset = dataset.map(self._read_eopatch)
+        dataset = eopatch_dataset(self.config.data_dir, features_data)
 
-        extract_fn = extract_patches(
+        extract_fn = extract_subpatches(
             self.config.patch_size,
             [('features', self.config.input_feature_axis),
              ('labels', self.config.labels_feature_axis)],
         )
-        dataset = dataset.flat_map(extract_fn)
+        dataset = dataset.interleave(extract_fn, self.config.interleave_size)
+
+        dataset = dataset.batch(self.config.batch_size)
 
         return dataset
 

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -6,7 +6,7 @@ from marshmallow.validate import OneOf
 from eolearn.core import EOPatch, FeatureType
 
 from ..base import BaseInput
-from .operations import extract_subpatches
+from .operations import extract_subpatches, augment_data
 
 _valid_types = [t.value for t in FeatureType]
 
@@ -91,6 +91,12 @@ class EOPatchInput(BaseInput):
         )
         dataset = dataset.interleave(extract_fn, self.config.interleave_size)
 
+        feature_augmentation = [
+            ('features', ['flip_left_right', 'rotate']),
+            ('labels', ['flip_left_right', 'rotate'])
+        ]
+        dataset = dataset.map(augment_data(feature_augmentation))
+        
         dataset = dataset.batch(self.config.batch_size)
 
         return dataset

--- a/eoflow/input/operations.py
+++ b/eoflow/input/operations.py
@@ -1,0 +1,135 @@
+import os
+import numpy as np
+import tensorflow as tf
+
+
+def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
+    """ Builds a TF op for building a dataset of subpatches from tensors. Subpatches sampling can be random or grid based. """
+
+    patch_w,patch_h = patch_size
+    def _fn(data):
+        feat_name_ref, axis_ref = spatial_features_and_axis[0]
+        ay_ref, ax_ref = axis_ref
+        # Get random coordinates
+        def _py_get_random(image):
+            x_space = image.shape[ax_ref]-patch_w
+            if x_space > 0:
+                x_rand = np.random.randint(x_space, size=num_random_samples, dtype=np.int64)
+            else:
+                x_rand = np.zeros(num_random_samples, np.int64)
+
+            y_space = image.shape[ay_ref]-patch_h
+            if y_space > 0:
+                y_rand = np.random.randint(y_space, size=num_random_samples, dtype=np.int64)
+            else:
+                y_rand = np.zeros(num_random_samples, np.int64)
+
+            return x_rand, y_rand
+
+        # Get coordinates on a grid
+        def _py_get_gridded(image):
+
+            # alpha is overlaping ratio (w.r.t. patch size)
+            alpha = grid_overlap
+
+            img_height = image.shape[ay_ref]
+            img_width = image.shape[ax_ref]
+
+            # number of patches in x and y direction
+            nx = int(np.ceil((img_width - alpha * patch_w) / (patch_w * (1 - alpha))))
+            ny = int(np.ceil((img_height - alpha * patch_h) / (patch_h * (1 - alpha))))
+
+            # total number of patches
+            N = nx * ny
+            # allocate output vectors (top-left patch coordinates)
+            tl_x = np.zeros(N, dtype=np.int64)
+            tl_y = np.zeros(N, dtype=np.int64)
+
+            # calculate actual x and y coordinates
+            for yi in range(ny):
+                if yi == 0:
+                    # the highest patch has x0 = 0
+                    y_ = 0
+                elif yi == ny - 1:
+                    # the lowest patch has y0 = H - patch_h
+                    y_ = img_height - patch_h
+                else:
+                    # calculate top-left y coordinate and take into account overlaping, too
+                    y_ = np.round(yi * patch_h - yi * alpha * patch_h)
+
+                for xi in range(nx):
+                    if xi == 0:
+                        # the left-most patch has x0 = 0
+                        x_ = 0
+                    elif xi == nx - 1:
+                        # the right-most patch has x0 = W - patch_w
+                        x_ = img_width - patch_w
+                    else:
+                        # calculate top-left x coordinate and take into account overlaping, too
+                        x_ = np.round(xi * patch_w - xi * alpha * patch_w)
+
+                    id = yi * nx + xi
+                    tl_x[id] = np.int64(x_)
+                    tl_y[id] = np.int64(y_)
+
+            return tl_x, tl_y
+
+        if random_sampling:
+            x_samp, y_samp = tf.py_func(_py_get_random, [data[feat_name_ref]], [tf.int64, tf.int64])
+        else:
+            x_samp, y_samp = tf.py_func(_py_get_gridded, [data[feat_name_ref]], [tf.int64, tf.int64])
+
+
+        def _py_get_patches(axis):
+            ay, ax = axis
+            # Extract patches for given coordinates
+            def _func(image, x_samp, y_samp):
+                patches = []
+
+                # Pad if necessary
+                x_pad = max(0, patch_w - image.shape[ax])
+                y_pad = max(0, patch_h - image.shape[ay])
+
+                if x_pad > 0 or y_pad > 0:
+                    pad_x1 = x_pad//2
+                    pad_x2 = x_pad - pad_x1
+                    pad_y1 = y_pad//2
+                    pad_y2 = y_pad - pad_y1
+
+                    padding = [(0,0) for _ in range(image.ndim)]
+                    padding[ax] = (pad_x1,pad_x2)
+                    padding[ay] = (pad_y1,pad_y2)
+                    image = np.pad(image, padding, 'constant')
+
+                # Extract patches
+                for x, y in zip(x_samp, y_samp):
+                    # Slice on specified axis
+                    slicing = [slice(None) for _ in range(image.ndim)]
+                    slicing[ax] = slice(x, x+patch_w)
+                    slicing[ay] = slice(y, y+patch_h)
+
+                    patch = image[slicing]
+                    patches.append(patch)
+                return np.stack(patches)
+
+            return _func
+
+        data_out = {}
+        # TODO: repeat the rest of the data
+        for feat_name, axis in spatial_features_and_axis:
+            ay, ax = axis
+            shape = data[feat_name].shape.as_list()
+            patches = tf.py_func(_py_get_patches(axis), [data[feat_name], x_samp, y_samp], data[feat_name].dtype)
+
+            # Update shape information
+            shape[ax] = patch_w
+            shape[ay] = patch_h
+            shape = [None] + shape
+            patches.set_shape(shape)
+
+            data_out[feat_name] = patches
+
+        # TODO: shuffle subpatches
+        return tf.data.Dataset.from_tensor_slices(data_out)
+
+    return _fn

--- a/eoflow/input/operations.py
+++ b/eoflow/input/operations.py
@@ -5,7 +5,20 @@ import tensorflow as tf
 from ..utils import create_dirs
 
 def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
-    """ Builds a TF op for building a dataset of subpatches from tensors. Subpatches sampling can be random or grid based. """
+    """ Builds a TF op for building a dataset of subpatches from tensors. Subpatches sampling can be random or grid based. 
+    
+    :param patch_size: Width and height of extracted patches
+    :type patch_size: (int, int)
+    :param spatial_features_and_axis: List of features from which subpatches are extracted and their height and width axis.
+                                      Elements are tuples of (feature_name, (axis_h, axis_w)).
+    :type spatial_features_and_axis: list of (string, (int, int))
+    :param random_sampling: If True random sampling is used. Else grid based sampling is used.
+    :type random_sampling: bool
+    :param num_random_samples: Defines the number of subpatches to sample, when random sampling is used.
+    :type num_random_samples: int
+    :param grid_overlap: Amount of overlap between subpatches extracted from a grid
+    :type grid_overlap: float
+    """
 
     patch_w,patch_h = patch_size
     def _fn(data):
@@ -136,7 +149,16 @@ def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=Fa
     return _fn
 
 def augment_data(features_to_augment, brightness_delta=0.1, contrast_bounds=(0.9,1.1)):
-    """ Builds a function that randomly augments features in specified ways. """
+    """ Builds a function that randomly augments features in specified ways. 
+    
+    param features_to_augment: List of features to augment and which operations to perform on them.
+                               Each element is of shape (feature, list_of_operations).
+    type features_to_augment: list of (str, list of str)
+    param brightness_delta: Maximum brightness change.
+    type brightness_delta: float
+    param contrast_bounds: Upper and lower bounds of contrast multiplier.
+    type contrast_bounds: (float, float)
+    """
     
     def _augment(data):
         contrast_lower, contrast_upper = contrast_bounds

--- a/eoflow/input/operations.py
+++ b/eoflow/input/operations.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import tensorflow as tf
 
+from ..utils import create_dirs
 
 def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
     """ Builds a TF op for building a dataset of subpatches from tensors. Subpatches sampling can be random or grid based. """
@@ -162,3 +163,20 @@ def augment_data(features_to_augment, brightness_delta=0.1, contrast_bounds=(0.9
         return data
 
     return _augment
+
+def cache_dataset(dataset, path):
+    """ Caches dataset into a file. Each element in the dataset will be computed only once. """
+
+    # Create dir if missing
+    directory = os.path.dirname(path)
+    create_dirs([directory])
+
+    # Cache
+    dataset = dataset.cache(path)
+
+    # Disable map and batch fusion to prevent a bug when caching
+    options = tf.data.Options()
+    options.experimental_optimization.map_and_batch_fusion = False
+    dataset = dataset.with_options(options)
+
+    return dataset

--- a/eoflow/input/random.py
+++ b/eoflow/input/random.py
@@ -32,7 +32,7 @@ class RandomClassificationInput(BaseInput):
 
         dataset = tf.data.Dataset.from_generator(
             self._generate_batch,
-            (tf.float32, tf.int64),
+            (tf.float32, tf.float32),
             (tf.TensorShape(input_shape), tf.TensorShape(output_shape))
         )
 
@@ -68,7 +68,7 @@ class RandomSegmentationInput(BaseInput):
 
         dataset = tf.data.Dataset.from_generator(
             self._generate_batch,
-            (tf.float32, tf.int64),
+            (tf.float32, tf.float32),
             (tf.TensorShape(input_shape), tf.TensorShape(output_shape))
         )
 

--- a/eoflow/models/fcn_model.py
+++ b/eoflow/models/fcn_model.py
@@ -128,9 +128,12 @@ class FCNModel(BaseModel):
         logits = self._net(x, is_training)
 
         if mode == ModelMode.TRAIN:
+            out_shape = tf.shape(logits)
+            labels_cropped = tf.image.resize_with_crop_or_pad(labels, out_shape[1], out_shape[2])
+
             # flatten tensors to apply class weighting
             flat_logits = tf.reshape(logits, [-1, self.config.n_classes])
-            flat_labels = tf.reshape(labels, [-1, self.config.n_classes])
+            flat_labels = tf.reshape(labels_cropped, [-1, self.config.n_classes])
 
             if self.config.class_weights is not None:
                 loss = weighted_cross_entropy(flat_logits, flat_labels, self.config.class_weights)

--- a/eoflow/models/rfcn_model.py
+++ b/eoflow/models/rfcn_model.py
@@ -139,9 +139,12 @@ class RFCNModel(BaseModel):
         logits = self._net(x, is_training)
 
         if mode == ModelMode.TRAIN:
+            out_shape = tf.shape(logits)
+            labels_cropped = tf.image.resize_with_crop_or_pad(labels, out_shape[1], out_shape[2])
+
             # flatten tensors to apply class weighting
             flat_logits = tf.reshape(logits, [-1, self.config.n_classes])
-            flat_labels = tf.reshape(labels, [-1, self.config.n_classes])
+            flat_labels = tf.reshape(labels_cropped, [-1, self.config.n_classes])
 
             if self.config.class_weights is not None:
                 loss = weighted_cross_entropy(flat_logits, flat_labels, self.config.class_weights)

--- a/eoflow/models/tfcn_model.py
+++ b/eoflow/models/tfcn_model.py
@@ -157,6 +157,11 @@ class TFCNModel(BaseModel):
             out_shape = tf.shape(logits)
             labels_cropped = tf.image.resize_with_crop_or_pad(labels, out_shape[1], out_shape[2])
 
+            self.add_summary(tf.summary.image('input', features[:,0,...][...,0:3]))
+            self.add_summary(tf.summary.image('labels_raw', labels[...,0:3]))
+            self.add_summary(tf.summary.image('labels', labels_cropped[...,0:3]))
+            self.add_summary(tf.summary.image('output', logits[...,0:3]))
+
             # flatten tensors to apply class weighting
             flat_logits = tf.reshape(logits, [-1, self.config.n_classes])
             flat_labels = tf.reshape(labels_cropped, [-1, self.config.n_classes])

--- a/eoflow/tasks/train.py
+++ b/eoflow/tasks/train.py
@@ -28,7 +28,7 @@ class TrainTask(BaseTask):
 
         model_input = cls(config)
 
-        dataset_fn = lambda: model_input.get_dataset()
+        dataset_fn = model_input.get_dataset
         return dataset_fn
 
     def run(self):

--- a/eoflow/tasks/train.py
+++ b/eoflow/tasks/train.py
@@ -28,61 +28,16 @@ class TrainTask(BaseTask):
 
         model_input = cls(config)
 
-        dataset = model_input.get_dataset()
-        return dataset
+        dataset_fn = lambda: model_input.get_dataset()
+        return dataset_fn
 
     def run(self):
-        # TODO: session configuration
-        with tf.Session() as sess: 
-            # Parse model input
-            dataset = self.parse_input()
-
-            iterator = dataset.make_initializable_iterator()
-            features, labels = iterator.get_next()
-
-            # Build model
-            train_op, loss_op, summaries_op = self.model.build_model(features, labels, ModelMode.TRAIN)
-
-            # Create saver
-            step_tensor = self.model.global_step_tensor
-            checkpoint_dir = os.path.join(self.config.output_directory, 'checkpoints')
-            create_dirs([checkpoint_dir])
-            checkpoint_path = os.path.join(checkpoint_dir, 'model.ckpt')
-            saver = tf.train.Saver()
-
-            # Create summary writer
-            create_dirs([checkpoint_dir])
-            summary_writer = tf.summary.FileWriter(self.config.output_directory, sess.graph)
-
-            # Initialize variables
-            initializer = tf.global_variables_initializer()
-            sess.run(initializer)
-
-            # Train
-            training_step = 1
-            for e in range(self.config.num_epochs):
-                sess.run(iterator.initializer)
-                print("Epoch %d/%d" % (e+1, self.config.num_epochs))
-
-                while True:
-                    try:
-                        # Compute and record summaries every summary_steps
-                        if training_step % self.config.summary_steps == 0:
-                            _, loss, step, summaries = sess.run([train_op, loss_op, step_tensor, summaries_op])
-
-                            summary_writer.add_summary(summaries, global_step=step)
-                        else:
-                            _, loss, step = sess.run([train_op, loss_op, step_tensor])
-
-                        # Show progress
-                        if training_step % self.config.progress_steps == 0:
-                            print("Step %d: %f" % (step, loss))
-
-                        # Model saving
-                        if training_step % self.config.save_steps == 0:
-                            print("Saving checkpoint at step %d." % step)
-                            saver.save(sess, checkpoint_path, global_step=step)
-
-                        training_step += 1
-                    except tf.errors.OutOfRangeError:
-                        break
+        dataset_fn = self.parse_input()
+        
+        self.model.train(dataset_fn,
+                         num_epochs=self.config.num_epochs,
+                         output_directory=self.config.output_directory,
+                         save_steps=self.config.save_steps,
+                         summary_steps=self.config.summary_steps,
+                         progress_steps=self.config.progress_steps
+                         )


### PR DESCRIPTION
## EOPatch reading

Implemented method `eopatch_dataset` for reading selected features from EOPatches into a tensorflow Dataset.

## Dataset transformations

Also added common dataset transformations: subpatch extraction, data augmentation, caching.

`extract_subpatches` creates a transformation that extracts multiple subpatches of given size from each patch in the dataset. Subpatches can be sampled randomly or from a grid.

`augment_data` creates a transformation that randomly augments each example with specified operations. Operations include rotation, flipping, brightness and contrast adjustment.

`cache_dataset` caches the content of the dataset to disk. This enables us to cache extracted patches. In this way EOPatch reading and subpatch extraction is only done during the first epoch. For the rest of training, cached data is used.

## EOPatch input method

`EOPatchInputExample` contains an example implementation of a input method that can be used in the configuration. The method shows a basic configurable dataset pipeline implementation.

## Models update

FCN, TFCN, RFCN models have been updated to recieve the labels of the same size as the input. Cropping is done internaly. Basic image summaries (input image, labels, predictions) have been added to these models as well.

Examples have been updated to fit the new model definition.

## EOPatch training example

A simple example that works on Slovenian LULC patches has been added. It showcases eopatch loading, subpatch extraction, caching and data augmentation. In order for the cache to not take up too much space, only 5 128x128 subpatches are extracted from each patch. The example can be run using the following command:

```bash
python -m eoflow.execute configs/tfcn_example_real.json 
```

Logs and summaries are saved into `temp/tfcn_svn_lulc` dir. The summaries can be visualized using the following command:

```bash
tensorboard --logdir temp/tfcn_svn_lulc
```