### PR TITLE
Model prediction

### DIFF
--- a/configs/tfcn_example_real_pred.json
+++ b/configs/tfcn_example_real_pred.json
@@ -1,0 +1,52 @@
+{
+    "model": {
+        "classname": "eoflow.models.TFCNModel",
+        "config": {
+            "learning_rate": 0.0001,
+            "n_layers": 3,
+            "n_classes": 10,
+            "keep_prob": 0.8,
+            "features_root": 16,
+            "conv_size": 3,
+            "conv_stride": 1,
+            "deconv_size": 2,
+            "add_dropout": true,
+            "add_batch_norm": false,
+            "bias_init": 0.0,
+            "padding": "VALID",
+            "pool_size": 2,
+            "pool_stride": 2,
+            "pool_time": false,
+            "single_encoding_conv": true,
+            "conv_size_reduce": 3,
+            "loss": "cross-entropy",
+            "image_summaries": true
+        }
+    },
+    "task": {
+        "classname": "eoflow.tasks.PredictTask",
+        "config": {
+            "model_directory": "./temp/tfcn_svn_lulc",
+            "input_config":{
+                "classname": "eoflow.input.eopatch.EOPatchInputExample",
+                "config": {
+                    "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/test",
+                    "input_feature_type": "data",
+                    "input_feature_name": "FEATURES",
+                    "input_feature_axis": [1,2],
+                    "input_feature_shape": [23, -1, -1, 9],
+                    "labels_feature_type": "mask_timeless",
+                    "labels_feature_name": "LULC_RABA",
+                    "labels_feature_axis": [0,1],
+                    "labels_feature_shape": [-1, -1, 1],
+                    "patch_size": [128, 128],
+                    "interleave_size": 3,
+                    "batch_size": 1,
+                    "num_classes": 10,
+                    "num_subpatches": 5
+                }
+            }
+        }
+    }
+  }
+  

--- a/eoflow/tasks/__init__.py
+++ b/eoflow/tasks/__init__.py
@@ -1,1 +1,2 @@
 from .train import TrainTask
+from .predict import PredictTask

--- a/eoflow/tasks/predict.py
+++ b/eoflow/tasks/predict.py
@@ -1,0 +1,33 @@
+import os
+
+import tensorflow as tf
+from marshmallow import Schema, fields
+
+from ..base import Configurable, BaseTask, BaseInput, ModelMode
+from ..base.configuration import ObjectConfiguration
+from ..utils import parse_classname, create_dirs
+
+class PredictTask(BaseTask):
+    class PredictTaskConfig(Schema):
+        model_directory = fields.String(required=True, description='Directory of the model', example='/tmp/model/')
+
+        input_config = fields.Nested(nested=ObjectConfiguration, required=True, description="Input type and configuration.")
+
+    def parse_input(self):
+        input_config = self.config.input_config
+        classname, config = input_config.classname, input_config.config
+
+        cls = parse_classname(classname)
+        if not issubclass(cls, BaseInput):
+            raise ValueError("Data input class does not inherit from BaseInput.")
+
+        model_input = cls(config)
+
+        dataset_fn = model_input.get_dataset
+        return dataset_fn
+
+    def run(self):
+        dataset_fn = self.parse_input()
+
+        predictions_list = self.model.predict(dataset_fn, self.config.model_directory)
+        # TODO: something with predictions


### PR DESCRIPTION
Added a `predict` method to the model class. It loads the latest checkpoint of the model and runs prediction on the specified input. Output of the predictions is defined by the model.

Prediction task is WIP. It runs prediction from configuration. An example configuration is provided. Currently nothing is done with the results of prediction. Some sort of saving to disk needs to be implemented.