### PR TITLE
Prediction visualization

### DIFF
--- a/configs/tfcn_example_real_eval.json
+++ b/configs/tfcn_example_real_eval.json
@@ -18,8 +18,7 @@
             "pool_stride": 2,
             "pool_time": false,
             "single_encoding_conv": true,
-            "conv_size_reduce": 3,
-            "image_summaries": true
+            "conv_size_reduce": 3
         }
     },
     "task": {

--- a/configs/tfcn_example_real_pred.json
+++ b/configs/tfcn_example_real_pred.json
@@ -18,8 +18,7 @@
             "pool_stride": 2,
             "pool_time": false,
             "single_encoding_conv": true,
-            "conv_size_reduce": 3,
-            "image_summaries": true
+            "conv_size_reduce": 3
         }
     },
     "task": {

--- a/configs/tfcn_example_real_train.json
+++ b/configs/tfcn_example_real_train.json
@@ -20,13 +20,14 @@
             "single_encoding_conv": true,
             "conv_size_reduce": 3,
             "loss": "cross-entropy",
-            "image_summaries": true
+            "image_summaries": true,
+            "prediction_visualization": true
         }
     },
     "task": {
         "classname": "eoflow.tasks.TrainTask",
         "config": {
-            "num_epochs": 5,
+            "num_epochs": 50,
             "model_directory": "./temp/tfcn_svn_lulc",
             "input_config":{
                 "classname": "examples.input.EOPatchInputExample",

--- a/configs/tfcn_example_real_train.json
+++ b/configs/tfcn_example_real_train.json
@@ -21,7 +21,6 @@
             "conv_size_reduce": 3,
             "loss": "focal_loss",
             "metrics": ["accuracy", "iou"],
-            "image_summaries": true,
             "prediction_visualization": true
         }
     },

--- a/configs/tfcn_example_real_train.json
+++ b/configs/tfcn_example_real_train.json
@@ -46,7 +46,8 @@
                     "batch_size": 5,
                     "num_classes": 10,
                     "cache_file": "./temp/tfcn_svn_lulc/dataset/cache",
-                    "num_subpatches": 5
+                    "num_subpatches": 5,
+                    "data_augmentation": true
                 }
             },
             "save_steps": 100,

--- a/configs/tfcn_example_real_train.json
+++ b/configs/tfcn_example_real_train.json
@@ -28,11 +28,12 @@
         "classname": "eoflow.tasks.TrainTask",
         "config": {
             "num_epochs": 50,
+            "iterations_per_epoch": 10,
             "model_directory": "./temp/tfcn_svn_lulc",
             "input_config":{
                 "classname": "examples.input.EOPatchInputExample",
                 "config": {
-                    "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/train",
+                    "data_dir": "/home/devis/Desktop/train-val-linear-v01-aws/train",
                     "input_feature_type": "data",
                     "input_feature_name": "FEATURES",
                     "input_feature_axis": [1,2],
@@ -43,7 +44,7 @@
                     "labels_feature_shape": [-1, -1, 1],
                     "patch_size": [128, 128],
                     "interleave_size": 3,
-                    "batch_size": 5,
+                    "batch_size": 2,
                     "num_classes": 10,
                     "cache_file": "./temp/tfcn_svn_lulc/dataset/cache",
                     "num_subpatches": 5,

--- a/configs/tfcn_example_real_train_and_eval.json
+++ b/configs/tfcn_example_real_train_and_eval.json
@@ -21,7 +21,6 @@
             "conv_size_reduce": 3,
             "loss": "focal_loss",
             "metrics": ["accuracy", "iou"],
-            "image_summaries": true,
             "prediction_visualization": true
         }
     },

--- a/configs/tfcn_example_real_train_and_eval.json
+++ b/configs/tfcn_example_real_train_and_eval.json
@@ -33,7 +33,7 @@
             "train_input_config":{
                 "classname": "examples.input.EOPatchInputExample",
                 "config": {
-                    "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/train",
+                    "data_dir": "/home/devis/Desktop/train-val-linear-v01-aws/train",
                     "input_feature_type": "data",
                     "input_feature_name": "FEATURES",
                     "input_feature_axis": [1,2],
@@ -44,7 +44,7 @@
                     "labels_feature_shape": [-1, -1, 1],
                     "patch_size": [128, 128],
                     "interleave_size": 3,
-                    "batch_size": 5,
+                    "batch_size": 2,
                     "num_classes": 10,
                     "cache_file": "./temp/tfcn_svn_lulc/dataset/cache_train",
                     "num_subpatches": 5,
@@ -54,7 +54,7 @@
             "val_input_config":{
                 "classname": "examples.input.EOPatchInputExample",
                 "config": {
-                    "data_dir": "/storage/jupyter/data/svn_lulc/data/train-val-linear-v01-aws/test",
+                    "data_dir": "/home/devis/Desktop/train-val-linear-v01-aws/test",
                     "input_feature_type": "data",
                     "input_feature_name": "FEATURES",
                     "input_feature_axis": [1,2],
@@ -65,14 +65,15 @@
                     "labels_feature_shape": [-1, -1, 1],
                     "patch_size": [128, 128],
                     "interleave_size": 3,
-                    "batch_size": 5,
+                    "batch_size": 2,
                     "num_classes": 10,
                     "cache_file": "./temp/tfcn_svn_lulc/dataset/cache_val",
                     "num_subpatches": 5
                 }
             },
             "save_steps": 100,
-            "summary_steps": 10
+            "summary_steps": 10,
+            "validation_steps": 10
         }
     }
   }

--- a/configs/tfcn_example_real_train_and_eval.json
+++ b/configs/tfcn_example_real_train_and_eval.json
@@ -47,7 +47,8 @@
                     "batch_size": 5,
                     "num_classes": 10,
                     "cache_file": "./temp/tfcn_svn_lulc/dataset/cache_train",
-                    "num_subpatches": 5
+                    "num_subpatches": 5,
+                    "data_augmentation": true
                 }
             },
             "val_input_config":{

--- a/configs/tfcn_example_real_train_and_eval.json
+++ b/configs/tfcn_example_real_train_and_eval.json
@@ -20,14 +20,15 @@
             "single_encoding_conv": true,
             "conv_size_reduce": 3,
             "loss": "cross-entropy",
-            "image_summaries": true
+            "image_summaries": true,
+            "prediction_visualization": true
         }
     },
     "task": {
         "classname": "eoflow.tasks.TrainAndEvaluateTask",
         "config": {
             "num_epochs": 100,
-            "iterations_per_epoch": 100,
+            "iterations_per_epoch": 10,
             "model_directory": "./temp/tfcn_svn_lulc",
             "train_input_config":{
                 "classname": "examples.input.EOPatchInputExample",

--- a/eoflow/base/base_input.py
+++ b/eoflow/base/base_input.py
@@ -1,5 +1,6 @@
 from . import Configurable
 
+
 class BaseInput(Configurable):
     def get_dataset(self):
         """Builds and returns a tensorflow Dataset object for reading the data."""

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -1,12 +1,8 @@
-import logging
 import os
-from enum import Enum
 
-from tqdm.auto import tqdm
 import tensorflow as tf
 
 from . import Configurable
-from ..utils import create_dirs, get_common_shape
 
 
 class BaseModel(tf.keras.Model, Configurable):
@@ -49,6 +45,7 @@ class BaseModel(tf.keras.Model, Configurable):
               dataset,
               num_epochs,
               model_directory,
+              iterations_per_epoch,
               save_steps='epoch',
               summary_steps=1,
               callbacks=[],
@@ -63,9 +60,12 @@ class BaseModel(tf.keras.Model, Configurable):
         :type num_epochs: int
         :param model_directory: Output directory, where the model checkpoints and summaries are saved.
         :type model_directory: str
+        :param iterations_per_epoch: Number of training steps to make every epoch.
+            Training dataset is repeated automatically when the end is reached.
+        :type iterations_per_epoch: int
         :param save_steps: Number of steps between saving model checkpoints.
         :type save_steps: int
-        :param summary_steps: Number of steps between recodring summaries.
+        :param summary_steps: Number of steps between recording summaries.
         :type summary_steps: int
 
         Other keyword parameters are passed to the Model.fit method.
@@ -82,12 +82,19 @@ class BaseModel(tf.keras.Model, Configurable):
                                                                  save_freq=save_steps,
                                                                  save_weights_only=True)
 
-        return self.fit(dataset,
+        return self.fit(dataset.repeat(),
                         epochs=num_epochs,
+                        steps_per_epoch=iterations_per_epoch,
                         callbacks=[tensorboard_callback, checkpoint_callback] + callbacks,
                         **kwargs)
 
-    def train_and_evaluate(self, train_dataset, val_dataset, num_epochs, iterations_per_epoch, model_directory,
+    def train_and_evaluate(self,
+                           train_dataset,
+                           val_dataset,
+                           num_epochs,
+                           iterations_per_epoch,
+                           model_directory,
+                           validation_steps=None,
                            save_steps=100, summary_steps=10, callbacks=[], **kwargs):
         """ Trains the model on a given dataset. At the end of each epoch an evaluation is performed on the provided
             validation dataset. Takes care of saving the model and recording summaries.
@@ -96,8 +103,8 @@ class BaseModel(tf.keras.Model, Configurable):
             The dataset must be of shape (features, labels) where features and labels contain the data
             in the shape required by the model.
         :type train_dataset: tf.data.Dataset
-        :param val_dataset_fn: Same as for `train_dataset`, but for the validation data.
-        :type val_dataset_fn: tf.data.Dataset
+        :param val_dataset: Same as for `train_dataset`, but for the validation data.
+        :type val_dataset: tf.data.Dataset
         :param num_epochs: Number of epochs. Epoch size is independent from the dataset size.
         :type num_epochs: int
         :param iterations_per_epoch: Number of training steps to make every epoch.
@@ -105,6 +112,9 @@ class BaseModel(tf.keras.Model, Configurable):
         :type iterations_per_epoch: int
         :param model_directory: Output directory, where the model checkpoints and summaries are saved.
         :type model_directory: str
+        :param validation_steps: Relevant if validation_data is provided and is a tf.data dataset. Total number of
+            steps to draw before stopping when performing validation at the end of every epoch.
+        :type validation_steps: int or None
         :param save_steps: Number of steps between saving model checkpoints.
         :type save_steps: int
         :param summary_steps: Number of steps between recodring summaries.
@@ -124,12 +134,10 @@ class BaseModel(tf.keras.Model, Configurable):
                                                                  save_freq=save_steps,
                                                                  save_weights_only=True)
 
-        # Repeat training dataset indefenetly
-        train_dataset = train_dataset.repeat()
-
-        return self.fit(train_dataset,
-                        validation_data=val_dataset,
+        return self.fit(train_dataset.repeat(),
+                        validation_data=val_dataset.repeat(),
                         epochs=num_epochs,
+                        validation_steps=validation_steps,
                         steps_per_epoch=iterations_per_epoch,
                         callbacks=[tensorboard_callback, checkpoint_callback] + callbacks,
                         **kwargs)

--- a/eoflow/base/base_model.py
+++ b/eoflow/base/base_model.py
@@ -51,6 +51,7 @@ class BaseModel(tf.keras.Model, Configurable):
               model_directory,
               save_steps='epoch',
               summary_steps=1,
+              callbacks=[],
               **kwargs):
         """ Trains the model on a given dataset. Takes care of saving the model and recording summaries.
 
@@ -83,11 +84,11 @@ class BaseModel(tf.keras.Model, Configurable):
 
         return self.fit(dataset,
                         epochs=num_epochs,
-                        callbacks=[tensorboard_callback, checkpoint_callback],
+                        callbacks=[tensorboard_callback, checkpoint_callback] + callbacks,
                         **kwargs)
 
     def train_and_evaluate(self, train_dataset, val_dataset, num_epochs, iterations_per_epoch, model_directory,
-                           save_steps=100, summary_steps=10, **kwargs):
+                           save_steps=100, summary_steps=10, callbacks=[], **kwargs):
         """ Trains the model on a given dataset. At the end of each epoch an evaluation is performed on the provided
             validation dataset. Takes care of saving the model and recording summaries.
 
@@ -130,5 +131,5 @@ class BaseModel(tf.keras.Model, Configurable):
                         validation_data=val_dataset,
                         epochs=num_epochs,
                         steps_per_epoch=iterations_per_epoch,
-                        callbacks=[tensorboard_callback, checkpoint_callback],
+                        callbacks=[tensorboard_callback, checkpoint_callback] + callbacks,
                         **kwargs)

--- a/eoflow/base/base_task.py
+++ b/eoflow/base/base_task.py
@@ -1,13 +1,15 @@
 from . import Configurable, BaseInput
 from ..utils import parse_classname
 
+
 class BaseTask(Configurable):
     def __init__(self, model, config_specs):
         super().__init__(config_specs)
 
         self.model = model
 
-    def parse_input(self, input_config):
+    @staticmethod
+    def parse_input(input_config):
         """ Builds the input dataset using the provided configuration. """
 
         classname, config = input_config.classname, input_config.config

--- a/eoflow/base/configuration.py
+++ b/eoflow/base/configuration.py
@@ -1,8 +1,10 @@
 from abc import ABC
 import inspect
+import json
+
 from marshmallow import Schema, fields
 from munch import Munch
-import json
+
 
 def dict_to_munch(obj):
     """ Recursively convert a dict to Munch. (there is a Munch.from_dict method, but it's not python3 compatible)

--- a/eoflow/input/eopatch.py
+++ b/eoflow/input/eopatch.py
@@ -6,7 +6,6 @@ from marshmallow.validate import OneOf
 from eolearn.core import EOPatch, FeatureType
 
 from ..base import BaseInput
-from .operations import extract_subpatches, augment_data, cache_dataset
 
 _valid_types = [t.value for t in FeatureType]
 
@@ -14,8 +13,8 @@ _valid_types = [t.value for t in FeatureType]
 def eopatch_dataset(root_dir_or_list, features_data, fill_na=None):
     """ Creates a tf dataset with features from saved EOPatches.
 
-    :param data_dir_or_list: Root directory containing eopatches or a list of eopatch directories.
-    :type data_dir_or_list: str or list(str)
+    :param root_dir_or_list: Root directory containing eopatches or a list of eopatch directories.
+    :type root_dir_or_list: str or list(str)
     :param features_data: List of tuples containing data about features to extract.
         Tuple structure: (feature_type, feature_name, out_feature_name, feature_dtype, feature_shape)
     :type features_data: (str, str, str, np.dtype, tuple)

--- a/eoflow/input/operations.py
+++ b/eoflow/input/operations.py
@@ -5,7 +5,8 @@ import tensorflow as tf
 from ..utils import create_dirs
 
 
-def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20, grid_overlap=0.2):
+def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=False, num_random_samples=20,
+                       grid_overlap=0.2):
     """ Builds a TF op for building a dataset of subpatches from tensors. Subpatches sampling can be random or grid based.
 
     :param patch_size: Width and height of extracted patches
@@ -21,11 +22,13 @@ def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=Fa
     :type grid_overlap: float
     """
 
-    patch_w,patch_h = patch_size
+    patch_w, patch_h = patch_size
+
     def _fn(data):
         feat_name_ref, axis_ref = spatial_features_and_axis[0]
         ay_ref, ax_ref = axis_ref
         # Get random coordinates
+
         def _py_get_random(image):
             x_space = image.shape[ax_ref]-patch_w
             if x_space > 0:
@@ -94,10 +97,10 @@ def extract_subpatches(patch_size, spatial_features_and_axis, random_sampling=Fa
         else:
             x_samp, y_samp = tf.py_function(_py_get_gridded, [data[feat_name_ref]], [tf.int64, tf.int64])
 
-
         def _py_get_patches(axis):
             ay, ax = axis
             # Extract patches for given coordinates
+
             def _func(image, x_samp, y_samp):
                 patches = []
 

--- a/eoflow/models/fcn_model.py
+++ b/eoflow/models/fcn_model.py
@@ -31,8 +31,6 @@ class FCNModel(BaseSegmentationModel):
 
         class_weights = fields.List(fields.Float, missing=None, description='Class weights used in training.')
 
-        image_summaries = fields.Bool(missing=False, description='Record images summaries.')
-
     def build(self, inputs_shape):
         """Builds the net for input x."""
 

--- a/eoflow/models/rfcn_model.py
+++ b/eoflow/models/rfcn_model.py
@@ -32,8 +32,6 @@ class RFCNModel(BaseModel):
 
         class_weights = fields.List(fields.Float, missing=None, description='Class weights used in training.')
 
-        image_summaries = fields.Bool(missing=False, description='Record images summaries.')
-
     def _net(self, x, is_training):
 
         net = x

--- a/eoflow/models/segmentation.py
+++ b/eoflow/models/segmentation.py
@@ -65,14 +65,26 @@ class CroppedMetric(tf.keras.metrics.Metric):
         return self.metric.get_config()
 
 class VisualizationCallback(tf.keras.callbacks.Callback):
+    """ Keras Callback for saving prediction visualizations to TensorBoard. """
+
     def __init__(self, val_images, log_dir, time_index=0, rgb_indices=[0,1,2]):
+        """
+        :param val_images: Images to run predictions on. Tuple of (images, labels).
+        :type val_images: (np.array, np.array)
+        :param log_dir: Directory where the TensorBoard logs are written.
+        :type log_dir: str
+        :param time_index: Time index to use, when multiple time slices are available, defaults to 0
+        :type time_index: int, optional
+        :param rgb_indices: Indices for R, G and B bands in the input image, defaults to [0,1,2]
+        :type rgb_indices: list, optional
+        """
         super().__init__()
 
         self.val_images = val_images
         self.time_index = time_index
         self.rgb_indices = rgb_indices
 
-        self.file_writer = tf.summary.create_file_writer(os.path.join(log_dir, 'predictions'))
+        self.file_writer = tf.summary.create_file_writer(log_dir)
 
     def plot_predictions(self, input_image, labels, predictions, n_classes):
         fig,(ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(18, 5))

--- a/eoflow/models/segmentation.py
+++ b/eoflow/models/segmentation.py
@@ -79,7 +79,7 @@ class VisualizationCallback(tf.keras.callbacks.Callback):
 
         scaled_image = np.clip(input_image*2.5, 0., 1.)
         ax1.imshow(scaled_image)
-        ax1.title.set_text('Input image (first slice)')
+        ax1.title.set_text('Input image')
 
         cnorm = mpl.colors.NoNorm()
         cmap = plt.cm.get_cmap('Set3', n_classes)
@@ -190,6 +190,7 @@ class BaseSegmentationModel(BaseModel):
         visualization_callback = VisualizationCallback(data, log_dir)
         return visualization_callback
 
+    # Override default method to add prediction visualization
     def train(self, dataset, num_epochs, model_directory, callbacks=[],
               save_steps='epoch', summary_steps=1, **kwargs):
 
@@ -203,6 +204,7 @@ class BaseSegmentationModel(BaseModel):
         super().train(dataset, num_epochs, model_directory, callbacks=callbacks + custom_callbacks,
                       save_steps=save_steps, summary_steps=summary_steps, **kwargs)
 
+    # Override default method to add prediction visualization
     def train_and_evaluate(self, train_dataset, val_dataset, num_epochs, iterations_per_epoch, model_directory,
                            save_steps=100, summary_steps=10, callbacks=[], **kwargs):
 

--- a/eoflow/models/segmentation.py
+++ b/eoflow/models/segmentation.py
@@ -89,6 +89,7 @@ class VisualizationCallback(tf.keras.callbacks.Callback):
         self.file_writer = tf.summary.create_file_writer(log_dir)
 
     def plot_predictions(self, input_image, labels, predictions, n_classes):
+        # TODO: fix figsize (too wide?)
         fig,(ax1,ax2,ax3) = plt.subplots(1, 3, figsize=(18, 5))
 
         scaled_image = np.clip(input_image*2.5, 0., 1.)

--- a/eoflow/models/tfcn_model.py
+++ b/eoflow/models/tfcn_model.py
@@ -34,8 +34,6 @@ class TFCNModel(BaseSegmentationModel):
 
         class_weights = fields.List(fields.Float, missing=None, description='Class weights used in training.')
 
-        image_summaries = fields.Bool(missing=False, description='Record images summaries.')
-
     def build(self, inputs_shape):
 
         x = tf.keras.layers.Input(inputs_shape[1:])

--- a/eoflow/tasks/train.py
+++ b/eoflow/tasks/train.py
@@ -7,6 +7,7 @@ from ..base.configuration import ObjectConfiguration
 class TrainTask(BaseTask):
     class TrainTaskConfig(Schema):
         num_epochs = fields.Int(required=True, description='Number of epochs used in training', example=50)
+        iterations_per_epoch = fields.Int(required=True, description='Number of training steps per epoch', example=100)
         model_directory = fields.String(required=True, description='Directory of the model output', example='/tmp/model/')
 
         input_config = fields.Nested(nested=ObjectConfiguration, required=True, description="Input type and configuration.")
@@ -22,6 +23,7 @@ class TrainTask(BaseTask):
         self.model.train(
             dataset,
             num_epochs=self.config.num_epochs,
+            iterations_per_epoch=self.config.iterations_per_epoch,
             model_directory=self.config.model_directory,
             save_steps=self.config.save_steps,
             summary_steps=self.config.summary_steps
@@ -37,6 +39,7 @@ class TrainAndEvaluateTask(BaseTask):
         train_input_config = fields.Nested(nested=ObjectConfiguration, required=True, description="Input type and configuration for training.")
         val_input_config = fields.Nested(nested=ObjectConfiguration, required=True, description="Input type and configuration for validation.")
 
+        validation_steps = fields.Int(missing=None, description="Number of batches to compute validation scores over")
         save_steps = fields.Int(missing=100, description="Number of training steps between model checkpoints.")
         summary_steps = fields.Int(missing=10, description="Number of training steps between recording summaries.")
 
@@ -46,10 +49,13 @@ class TrainAndEvaluateTask(BaseTask):
 
         self.model.prepare()
 
+        self.model.summary()
+
         self.model.train_and_evaluate(
             train_dataset, val_dataset,
             num_epochs=self.config.num_epochs,
             iterations_per_epoch=self.config.iterations_per_epoch,
+            validation_steps=self.config.validation_steps,
             model_directory=self.config.model_directory,
             save_steps=self.config.save_steps,
             summary_steps=self.config.summary_steps

--- a/eoflow/utils/tf_utils.py
+++ b/eoflow/utils/tf_utils.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 import io
 import matplotlib.pyplot as plt
 
+
 def plot_to_image(figure):
     """ Converts the matplotlib plot specified by 'figure' to a PNG image and
     returns it. The supplied figure is closed and inaccessible after this call. """

--- a/eoflow/utils/tf_utils.py
+++ b/eoflow/utils/tf_utils.py
@@ -1,0 +1,20 @@
+import tensorflow as tf
+import io
+import matplotlib.pyplot as plt
+
+def plot_to_image(figure):
+    """ Converts the matplotlib plot specified by 'figure' to a PNG image and
+    returns it. The supplied figure is closed and inaccessible after this call. """
+
+    # Save the plot to a PNG in memory.
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    # Closing the figure prevents it from being displayed directly inside
+    # the notebook.
+    plt.close(figure)
+    buf.seek(0)
+    # Convert PNG buffer to TF image
+    image = tf.image.decode_png(buf.getvalue(), channels=4)
+    # Add the batch dimension
+    image = tf.expand_dims(image, 0)
+    return image

--- a/eoflow/utils/utils.py
+++ b/eoflow/utils/utils.py
@@ -1,8 +1,10 @@
 import os
 from pydoc import locate
 
+
 def parse_classname(classname):
     return locate(classname)
+
 
 def create_dirs(dirs):
     """
@@ -18,6 +20,7 @@ def create_dirs(dirs):
     except Exception as err:
         print("Creating directories error: {0}".format(err))
         exit(-1)
+
 
 def get_common_shape(shape1, shape2):
     """ Get a common shape that fits both shapes. Dimensions that differ in size are set to None.

--- a/examples/input.py
+++ b/examples/input.py
@@ -58,6 +58,7 @@ class EOPatchInputExample(BaseInput):
         num_subpatches = fields.Int(required=True, description="Number of subpatches extracted by random sampling.", example=5)
 
         interleave_size = fields.Int(description="Number of eopatches to interleave the subpatches from.", required=True, example=5)
+        data_augmentation = fields.Bool(missing=False, description="Use data augmentation on images.")
 
         cache_file = fields.String(
             missing=None, description="A path to the file where the dataset will be cached. No caching if not provided.", example='/tmp/data')
@@ -93,11 +94,12 @@ class EOPatchInputExample(BaseInput):
             dataset = cache_dataset(dataset, self.config.cache_file)
 
         # Data augmentation
-        feature_augmentation = [
-            ('features', ['flip_left_right', 'rotate', 'brightness']),
-            ('labels', ['flip_left_right', 'rotate'])
-        ]
-        dataset = dataset.map(augment_data(feature_augmentation))
+        if cfg.data_augmentation:
+            feature_augmentation = [
+                ('features', ['flip_left_right', 'rotate', 'brightness']),
+                ('labels', ['flip_left_right', 'rotate'])
+            ]
+            dataset = dataset.map(augment_data(feature_augmentation))
 
         # One-hot encode labels and return tuple
         def _prepare_data(data):

--- a/examples/input.py
+++ b/examples/input.py
@@ -1,7 +1,6 @@
 import numpy as np
 import tensorflow as tf
 from marshmallow import fields, Schema
-from marshmallow.validate import OneOf
 
 from eolearn.core import FeatureType
 from eoflow.base import BaseInput
@@ -9,6 +8,7 @@ from eoflow.input.eopatch import eopatch_dataset, EOPatchSegmentationInput
 from eoflow.input.operations import extract_subpatches, augment_data, cache_dataset
 
 _valid_types = [t.value for t in FeatureType]
+
 
 class ExampleInput(BaseInput):
     """ A simple example of an Input class. Produces random data. """
@@ -49,7 +49,8 @@ class ExampleInput(BaseInput):
 
 
 class EOPatchInputExample(BaseInput):
-    """ An example input method for EOPatches. Shows feature reading, subpatch extraction, data augmentation, caching, batching, etc. """
+    """ An example input method for EOPatches. Shows feature reading, subpatch extraction, data augmentation,
+     caching, batching, etc. """
 
     # Configuration schema (extended from EOPatchSegmentationInput)
     class _Schema(EOPatchSegmentationInput._Schema):
@@ -63,7 +64,8 @@ class EOPatchInputExample(BaseInput):
         cache_file = fields.String(
             missing=None, description="A path to the file where the dataset will be cached. No caching if not provided.", example='/tmp/data')
 
-    def _parse_shape(self, shape):
+    @staticmethod
+    def _parse_shape(shape):
         shape = [None if s<0 else s for s in shape]
         return shape
 
@@ -83,8 +85,8 @@ class EOPatchInputExample(BaseInput):
             self.config.patch_size,
             [('features', self.config.input_feature_axis),
              ('labels', self.config.labels_feature_axis)],
-             random_sampling=True,
-             num_random_samples=self.config.num_subpatches
+            random_sampling=True,
+            num_random_samples=self.config.num_subpatches
         )
         # Interleave patches extracted from multiple EOPatches
         dataset = dataset.interleave(extract_fn, self.config.interleave_size)
@@ -113,6 +115,6 @@ class EOPatchInputExample(BaseInput):
         dataset = dataset.map(_prepare_data)
 
         # Create batches
-        dataset = dataset.batch(self.config.batch_size)
+        dataset = dataset.batch(self.config.batch_size).repeat()
 
         return dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 eo-learn-core
-eo-learn-io
 munch
 tensorflow>=2.0
-marshmallow
 numpy
-tqdm
-scipy
-scikit-image
+marshmallow
+matplotlib


### PR DESCRIPTION
Implemented input image, labels and predictions visualization for segmentation tasks.

`VisualizationCallback` is a Keras callback object, that runs the prediction on provided input images, creates visualization and exports it to to tensorboard. The input images and labels have to be provided in form of a numpy array (or tensors) when constructing the `VisualizationCallback` object. Bellow is an example visualization as seen in TensorBoard.

<img width="947" alt="visualization" src="https://user-images.githubusercontent.com/11095696/69746022-ae1f7680-1143-11ea-827b-4e4b5f7a6b49.png">

The visualization are recorded after each epoch. In TensorBoard you can use the step slider to scroll over visualizations at different time steps and see how the model is improving.

The callback has been integrated into `BaseSegmentationModel`. It can be configured by parameters `prediction_visualization` and `prediction_visualization_num`, which specify whether or not to use the visualization and how many images to visualize. The visualization extracts the first `prediction_visualization_num` images from the training set (or validation set if using `train_and_evaluate`) and uses those images for visualizations.

All models inhereting from `BaseSegmentationModel` will have this functionality by default (when using `train` or `train_and_evaluate` methods).
`VisualizationCallback` can be also used in custom code with custom test images (e.g. hand picked examples) and passed to model training methods in the parameter `callbacks`.

Other changes:
* added `data_augmentation` parameter to `EOPatchInputExample`. By default the data augmentation is turned off.