### PR TITLE
Add weights to losses

### DIFF
--- a/eoflow/models/callbacks.py
+++ b/eoflow/models/callbacks.py
@@ -1,0 +1,91 @@
+import tensorflow as tf
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+from ..utils.tf_utils import plot_to_image
+
+
+class VisualizationCallback(tf.keras.callbacks.Callback):
+    """ Keras Callback for saving prediction visualizations to TensorBoard. """
+
+    def __init__(self, val_images, log_dir, time_index=0, rgb_indices=[2, 1, 0]):
+        """
+        :param val_images: Images to run predictions on. Tuple of (images, labels).
+        :type val_images: (np.array, np.array)
+        :param log_dir: Directory where the TensorBoard logs are written.
+        :type log_dir: str
+        :param time_index: Time index to use, when multiple time slices are available, defaults to 0
+        :type time_index: int, optional
+        :param rgb_indices: Indices for R, G and B bands in the input image, defaults to [0,1,2]
+        :type rgb_indices: list, optional
+        """
+        super().__init__()
+
+        self.val_images = val_images
+        self.time_index = time_index
+        self.rgb_indices = rgb_indices
+
+        self.file_writer = tf.summary.create_file_writer(log_dir)
+
+    @staticmethod
+    def plot_predictions(input_image, labels, predictions, n_classes):
+        # TODO: fix figsize (too wide?)
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(18, 5))
+
+        scaled_image = np.clip(input_image*2.5, 0., 1.)
+        ax1.imshow(scaled_image)
+        ax1.title.set_text('Input image')
+
+        cnorm = mpl.colors.NoNorm()
+        cmap = plt.cm.get_cmap('Set3', n_classes)
+
+        ax2.imshow(labels, cmap=cmap, norm=cnorm)
+        ax2.title.set_text('Labeled classes')
+
+        img = ax3.imshow(predictions, cmap=cmap, norm=cnorm)
+        ax3.title.set_text('Predicted classes')
+
+        plt.colorbar(img, ax=[ax1, ax2, ax3], shrink=0.8, ticks=list(range(n_classes)))
+
+        return fig
+
+    def prediction_summaries(self, step):
+        images, labels = self.val_images
+        preds_raw = self.model.predict(images)
+
+        pred_shape = tf.shape(preds_raw)
+
+        # If temporal data only use time_index slice
+        if images.ndim == 5:
+            images = images[:, self.time_index, :, :, :]
+
+        # Crop images and labels to output size
+        labels = tf.image.resize_with_crop_or_pad(labels, pred_shape[1], pred_shape[2])
+        images = tf.image.resize_with_crop_or_pad(images, pred_shape[1], pred_shape[2])
+
+        # Take RGB values
+        images = images.numpy()[..., self.rgb_indices]
+
+        num_classes = labels.shape[-1]
+
+        # Get class ids
+        preds_raw = np.argmax(preds_raw, axis=-1)
+        labels = np.argmax(labels, axis=-1)
+
+        vis_images = []
+        for image_i, labels_i, pred_i in zip(images, labels, preds_raw):
+            # Plot predictions and convert to image
+            fig = self.plot_predictions(image_i, labels_i, pred_i, num_classes)
+            img = plot_to_image(fig)
+
+            vis_images.append(img)
+
+        n_images = len(vis_images)
+        vis_images = tf.concat(vis_images, axis=0)
+
+        with self.file_writer.as_default():
+            tf.summary.image('predictions', vis_images, step=step, max_outputs=n_images)
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.prediction_summaries(epoch)

--- a/eoflow/models/losses.py
+++ b/eoflow/models/losses.py
@@ -2,6 +2,57 @@ import tensorflow as tf
 from tensorflow.keras.losses import Loss, Reduction
 
 
+def cropped_loss(loss_fn):
+    """ Wraps loss function. Crops the labels to match the logits size. """
+
+    def _loss_fn(labels, logits):
+        logits_shape = tf.shape(logits)
+        labels_crop = tf.image.resize_with_crop_or_pad(labels, logits_shape[1], logits_shape[2])
+
+        return loss_fn(labels_crop, logits)
+
+    return _loss_fn
+
+
+class CategoricalCrossEntropy(Loss):
+    """ Wrapper class for cross-entropy with class weights """
+    def __init__(self, from_logits=True, class_weights=None, reduction=Reduction.AUTO, name='FocalLoss'):
+        """Categorical cross-entropy.
+
+        :param from_logits: Whether predictions are logits or softmax, defaults to True
+        :type from_logits: bool
+        :param reduction: reduction to be used, defaults to Reduction.AUTO
+        :type reduction: tf.keras.losses.Reduction, optional
+        :param name: name of the loss, defaults to 'FocalLoss'
+        :type name: str
+        """
+        super().__init__(reduction=reduction, name=name)
+
+        self.from_logits = from_logits
+        self.class_weights = class_weights
+
+    def call(self, y_true, y_pred):
+        # Perform softmax
+        if self.from_logits:
+            y_pred = tf.nn.softmax(y_pred)
+
+        # Clip the prediction value to prevent NaN's and Inf's
+        epsilon = tf.keras.backend.epsilon()
+        y_pred = tf.clip_by_value(y_pred, epsilon, 1.)
+
+        # Calculate Cross Entropy
+        loss = -y_true * tf.math.log(y_pred)
+
+        # Multiply cross-entropy with class-wise weights
+        if self.class_weights is not None:
+            loss = tf.multiply(loss, self.class_weights)
+
+        # Sum over classes
+        loss = tf.reduce_sum(loss, axis=-1)
+
+        return loss
+
+
 class CategoricalFocalLoss(Loss):
     """ Categorical version of focal loss.
 
@@ -10,7 +61,8 @@ class CategoricalFocalLoss(Loss):
         Keras implementation: https://github.com/umbertogriffo/focal-loss-keras
     """
 
-    def __init__(self, gamma=2., alpha=.25, from_logits=True, reduction=Reduction.AUTO, name='FocalLoss'):
+    def __init__(self, gamma=2., alpha=.25, from_logits=True, class_weights=None, reduction=Reduction.AUTO,
+                 name='FocalLoss'):
         """Categorical version of focal loss.
 
         :param gamma: gamma value, defaults to 2.
@@ -29,6 +81,7 @@ class CategoricalFocalLoss(Loss):
         self.gamma = gamma
         self.alpha = alpha
         self.from_logits = from_logits
+        self.class_weights = class_weights
 
     def call(self, y_true, y_pred):
 
@@ -46,6 +99,10 @@ class CategoricalFocalLoss(Loss):
         # Calculate Focal Loss
         loss = self.alpha * tf.math.pow(1 - y_pred, self.gamma) * cross_entropy
 
+        # Multiply focal loss with class-wise weights
+        if self.class_weights is not None:
+            loss = tf.multiply(cross_entropy, self.class_weights)
+
         # Sum over classes
         loss = tf.reduce_sum(loss, axis=-1)
 
@@ -60,7 +117,7 @@ class JaccardDistanceLoss(Loss):
 
     Implementation taken from https://github.com/keras-team/keras-contrib/blob/master/keras_contrib/losses/jaccard.py
     """
-    def __init__(self, smooth=1, from_logits=True, reduction=Reduction.AUTO, name='JaccardLoss'):
+    def __init__(self, smooth=1, from_logits=True, class_weights=None, reduction=Reduction.AUTO, name='JaccardLoss'):
         """ Jaccard distance loss.
 
         :param smooth: Smoothing factor. Default is 1.
@@ -77,6 +134,8 @@ class JaccardDistanceLoss(Loss):
         self.smooth = smooth
         self.from_logits = from_logits
 
+        self.class_weights = class_weights
+
     def call(self, y_true, y_pred):
 
         # Perform softmax
@@ -89,6 +148,11 @@ class JaccardDistanceLoss(Loss):
 
         jac = (intersection + self.smooth) / (sum_ - intersection + self.smooth)
 
-        loss = tf.reduce_mean((1 - jac) * self.smooth)
+        loss = (1 - jac) * self.smooth
+
+        if self.class_weights is not None:
+            loss = tf.multiply(loss, self.class_weights)
+
+        loss = tf.reduce_sum(loss, axis=-1)
 
         return loss

--- a/eoflow/models/losses.py
+++ b/eoflow/models/losses.py
@@ -21,6 +21,8 @@ class CategoricalCrossEntropy(Loss):
 
         :param from_logits: Whether predictions are logits or softmax, defaults to True
         :type from_logits: bool
+        :param class_weights: Array of class weights to be applied to loss. Needs to be of `n_classes` length
+        :type class_weights: np.array
         :param reduction: reduction to be used, defaults to Reduction.AUTO
         :type reduction: tf.keras.losses.Reduction, optional
         :param name: name of the loss, defaults to 'FocalLoss'
@@ -71,6 +73,8 @@ class CategoricalFocalLoss(Loss):
         :type alpha: float
         :param from_logits: Whether predictions are logits or softmax, defaults to True
         :type from_logits: bool
+        :param class_weights: Array of class weights to be applied to loss. Needs to be of `n_classes` length
+        :type class_weights: np.array
         :param reduction: reduction to be used, defaults to Reduction.AUTO
         :type reduction: tf.keras.losses.Reduction, optional
         :param name: name of the loss, defaults to 'FocalLoss'
@@ -124,6 +128,8 @@ class JaccardDistanceLoss(Loss):
         :type smooth: int
         :param from_logits: Whether predictions are logits or softmax, defaults to True
         :type from_logits: bool
+        :param class_weights: Array of class weights to be applied to loss. Needs to be of `n_classes` length
+        :type class_weights: np.array
         :param reduction: reduction to be used, defaults to Reduction.AUTO
         :type reduction: tf.keras.losses.Reduction, optional
         :param name: name of the loss, defaults to 'JaccardLoss'

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -70,3 +70,26 @@ class MeanIoU(InitializableMetric):
         self.assert_initialized()
 
         return self.metric.get_config()
+
+
+class CroppedMetric(tf.keras.metrics.Metric):
+    """ Wraps a metric. Crops the labels to match the logits size. """
+
+    def __init__(self, metric):
+        super().__init__(name=metric.name, dtype=metric.dtype)
+        self.metric = metric
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        logits_shape = tf.shape(y_pred)
+        labels_crop = tf.image.resize_with_crop_or_pad(y_true, logits_shape[1], logits_shape[2])
+
+        return self.metric.update_state(labels_crop, y_pred, sample_weight)
+
+    def result(self):
+        return self.metric.result()
+
+    def reset_states(self):
+        return self.metric.reset_states()
+
+    def get_config(self):
+        return self.metric.get_config()

--- a/eoflow/models/segmentation.py
+++ b/eoflow/models/segmentation.py
@@ -1,18 +1,16 @@
 import os
 import logging
 
-import tensorflow as tf
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
+import tensorflow as tf
 from marshmallow import Schema, fields
 from marshmallow.validate import OneOf, ContainsOnly
 
 from ..base import BaseModel
-from ..utils.tf_utils import plot_to_image
 
-from .losses import CategoricalFocalLoss, JaccardDistanceLoss
-from .metrics import MeanIoU, InitializableMetric
+from .losses import CategoricalCrossEntropy, CategoricalFocalLoss, JaccardDistanceLoss, cropped_loss
+from .metrics import MeanIoU, InitializableMetric, CroppedMetric
+from .callbacks import VisualizationCallback
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s %(message)s')
@@ -20,9 +18,9 @@ logging.basicConfig(level=logging.INFO,
 
 # Available losses. Add keys with new losses here.
 segmentation_losses = {
-    'cross_entropy': tf.keras.losses.CategoricalCrossentropy(from_logits=True),
-    'focal_loss': CategoricalFocalLoss(from_logits=True),
-    'jaccard_loss': JaccardDistanceLoss(from_logits=True)
+    'cross_entropy': CategoricalCrossEntropy,
+    'focal_loss': CategoricalFocalLoss,
+    'jaccard_loss': JaccardDistanceLoss
 }
 
 
@@ -31,126 +29,6 @@ segmentation_metrics = {
     'accuracy': tf.keras.metrics.CategoricalAccuracy(name='accuracy'),
     'iou': MeanIoU(default_max_classes=32)
 }
-
-
-def cropped_loss(loss_fn):
-    """ Wraps loss function. Crops the labels to match the logits size. """
-
-    def _loss_fn(labels, logits):
-        logits_shape = tf.shape(logits)
-        labels_crop = tf.image.resize_with_crop_or_pad(labels, logits_shape[1], logits_shape[2])
-
-        return loss_fn(labels_crop, logits)
-
-    return _loss_fn
-
-
-class CroppedMetric(tf.keras.metrics.Metric):
-    """ Wraps a metric. Crops the labels to match the logits size. """
-
-    def __init__(self, metric):
-        super().__init__(name=metric.name, dtype=metric.dtype)
-        self.metric = metric
-
-    def update_state(self, y_true, y_pred, sample_weight=None):
-        logits_shape = tf.shape(y_pred)
-        labels_crop = tf.image.resize_with_crop_or_pad(y_true, logits_shape[1], logits_shape[2])
-
-        return self.metric.update_state(labels_crop, y_pred, sample_weight)
-
-    def result(self):
-        return self.metric.result()
-
-    def reset_states(self):
-        return self.metric.reset_states()
-
-    def get_config(self):
-        return self.metric.get_config()
-
-
-class VisualizationCallback(tf.keras.callbacks.Callback):
-    """ Keras Callback for saving prediction visualizations to TensorBoard. """
-
-    def __init__(self, val_images, log_dir, time_index=0, rgb_indices=[2, 1, 0]):
-        """
-        :param val_images: Images to run predictions on. Tuple of (images, labels).
-        :type val_images: (np.array, np.array)
-        :param log_dir: Directory where the TensorBoard logs are written.
-        :type log_dir: str
-        :param time_index: Time index to use, when multiple time slices are available, defaults to 0
-        :type time_index: int, optional
-        :param rgb_indices: Indices for R, G and B bands in the input image, defaults to [0,1,2]
-        :type rgb_indices: list, optional
-        """
-        super().__init__()
-
-        self.val_images = val_images
-        self.time_index = time_index
-        self.rgb_indices = rgb_indices
-
-        self.file_writer = tf.summary.create_file_writer(log_dir)
-
-    @staticmethod
-    def plot_predictions(input_image, labels, predictions, n_classes):
-        # TODO: fix figsize (too wide?)
-        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(18, 5))
-
-        scaled_image = np.clip(input_image*2.5, 0., 1.)
-        ax1.imshow(scaled_image)
-        ax1.title.set_text('Input image')
-
-        cnorm = mpl.colors.NoNorm()
-        cmap = plt.cm.get_cmap('Set3', n_classes)
-
-        ax2.imshow(labels, cmap=cmap, norm=cnorm)
-        ax2.title.set_text('Labeled classes')
-
-        img = ax3.imshow(predictions, cmap=cmap, norm=cnorm)
-        ax3.title.set_text('Predicted classes')
-
-        plt.colorbar(img, ax=[ax1, ax2, ax3], shrink=0.8, ticks=list(range(n_classes)))
-
-        return fig
-
-    def prediction_summaries(self, step):
-        images, labels = self.val_images
-        preds_raw = self.model.predict(images)
-
-        pred_shape = tf.shape(preds_raw)
-
-        # If temporal data only use time_index slice
-        if images.ndim == 5:
-            images = images[:, self.time_index, :, :, :]
-
-        # Crop images and labels to output size
-        labels = tf.image.resize_with_crop_or_pad(labels, pred_shape[1], pred_shape[2])
-        images = tf.image.resize_with_crop_or_pad(images, pred_shape[1], pred_shape[2])
-
-        # Take RGB values
-        images = images.numpy()[..., self.rgb_indices]
-
-        num_classes = labels.shape[-1]
-
-        # Get class ids
-        preds_raw = np.argmax(preds_raw, axis=-1)
-        labels = np.argmax(labels, axis=-1)
-
-        vis_images = []
-        for image_i, labels_i, pred_i in zip(images, labels, preds_raw):
-            # Plot predictions and convert to image
-            fig = self.plot_predictions(image_i, labels_i, pred_i, num_classes)
-            img = plot_to_image(fig)
-
-            vis_images.append(img)
-
-        n_images = len(vis_images)
-        vis_images = tf.concat(vis_images, axis=0)
-
-        with self.file_writer.as_default():
-            tf.summary.image('predictions', vis_images, step=step, max_outputs=n_images)
-
-    def on_epoch_end(self, epoch, logs=None):
-        self.prediction_summaries(epoch)
 
 
 class BaseSegmentationModel(BaseModel):
@@ -165,8 +43,19 @@ class BaseSegmentationModel(BaseModel):
                               description='List of metrics used for evaluation.',
                               validate=ContainsOnly(segmentation_metrics.keys()))
 
+        class_weights = fields.Dict(missing=None, description='Dictionary mapping class id with weight. '
+                                                              'If key for some labels is not specified, 1 is used.')
+
         prediction_visualization = fields.Bool(missing=False, description='Record prediction visualization summaries.')
-        prediction_visualization_num = fields.Int(missing=5, description='Number of images used for prediction visualization.')
+        prediction_visualization_num = fields.Int(missing=5,
+                                                  description='Number of images used for prediction visualization.')
+
+    def _prepare_class_weights(self):
+        """ Utility function to parse class weights """
+        if self.config.class_weights is None:
+            return np.ones(self.config.n_classes)
+        return np.array([self.config.class_weights[iclass] if iclass in self.config.class_weights else 1.0
+                         for iclass in range(self.config.n_classes)])
 
     def prepare(self, optimizer=None, loss=None, metrics=None, **kwargs):
         """ Prepares the model. Optimizer, loss and metrics are read using the following protocol:
@@ -175,7 +64,6 @@ class BaseSegmentationModel(BaseModel):
         * Otherwise the argument is passed to `compile` as is.
 
         """
-
         # Read defaults if None
         if optimizer is None:
             optimizer = tf.keras.optimizers.Adam(learning_rate=self.config.learning_rate)
@@ -186,9 +74,12 @@ class BaseSegmentationModel(BaseModel):
         if metrics is None:
             metrics = self.config.metrics
 
+        class_weights = self._prepare_class_weights()
+
         # Wrap loss function
+        # TODO: pass kwargs to loss from config
         if loss in segmentation_losses:
-            loss = segmentation_losses[loss]
+            loss = segmentation_losses[loss](from_logits=True, class_weights=class_weights)
         wrapped_loss = cropped_loss(loss)
 
         # Wrap metrics
@@ -219,6 +110,7 @@ class BaseSegmentationModel(BaseModel):
               num_epochs,
               model_directory,
               iterations_per_epoch,
+              class_weights=None,
               callbacks=[],
               save_steps='epoch',
               summary_steps=1, **kwargs):
@@ -241,6 +133,7 @@ class BaseSegmentationModel(BaseModel):
                            num_epochs,
                            iterations_per_epoch,
                            model_directory,
+                           class_weights=None,
                            validation_steps=1,
                            save_steps=100,
                            summary_steps=10,

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,29 +1,27 @@
 import unittest
 import numpy as np
 
-from eoflow.models.losses import CategoricalFocalLoss, JaccardDistanceLoss
+from eoflow.models.losses import CategoricalCrossEntropy, CategoricalFocalLoss, JaccardDistanceLoss
 
 
-class TestFocalLoss(unittest.TestCase):
+class TestLosses(unittest.TestCase):
     def test_shapes(self):
-        loss_fn = CategoricalFocalLoss(from_logits=True)
+        for loss_fn in [CategoricalFocalLoss(from_logits=True), CategoricalCrossEntropy(from_logits=True)]:
 
-        ones_1 = np.ones((1, 1024, 2))
-        ones_2 = np.ones((1, 32, 32, 2))
+            ones_1 = np.ones((1, 1024, 2))
+            ones_2 = np.ones((1, 32, 32, 2))
 
-        val1 = loss_fn(ones_1, 1-ones_1).numpy()
-        val2 = loss_fn(ones_2, 1-ones_2).numpy()
+            val1 = loss_fn(ones_1, 1-ones_1).numpy()
+            val2 = loss_fn(ones_2, 1-ones_2).numpy()
 
-        # Values should be scalars
-        self.assertEqual(val1.shape, ())
-        self.assertEqual(val2.shape, ())
+            # Values should be scalars
+            self.assertEqual(val1.shape, ())
+            self.assertEqual(val2.shape, ())
 
-        # Loss values should be equal as they represent the same data, just in different shapes
-        self.assertAlmostEqual(val1, val2, 10)
+            # Loss values should be equal as they represent the same data, just in different shapes
+            self.assertAlmostEqual(val1, val2, 10)
 
-    def test_loss_values(self):
-        loss_fn = CategoricalFocalLoss(from_logits=False)
-
+    def test_focal_loss_values(self):
         ones = np.ones((32, 32))
         zeros = np.zeros((32, 32))
         mixed = np.concatenate([ones[:16], zeros[:16]])
@@ -31,19 +29,22 @@ class TestFocalLoss(unittest.TestCase):
         # Predict everything as class 1
         y_pred = np.stack([zeros, ones], axis=-1)
 
-        y_true1 = np.stack([ones, zeros], axis=-1) # All class 0
-        y_true2 = np.stack([zeros, ones], axis=-1) # All class 1
-        y_true3 = np.stack([mixed, 1-mixed], axis=-1) # Half class 1, half class 0
+        y_true1 = np.stack([ones, zeros], axis=-1)  # All class 0
+        y_true2 = np.stack([zeros, ones], axis=-1)  # All class 1
+        y_true3 = np.stack([mixed, 1-mixed], axis=-1)  # Half class 1, half class 0
 
-        # Compute loss values for different labels
-        val1 = loss_fn(y_true1, y_pred).numpy() # Should be biggest (all are wrong)
-        val2 = loss_fn(y_true2, y_pred).numpy() # Should be 0 (all are correct)
-        val3 = loss_fn(y_true3, y_pred).numpy() # Should be in between (half are correct)
+        for loss_fn in [CategoricalFocalLoss(from_logits=False),
+                        CategoricalFocalLoss(from_logits=False, class_weights=np.array([0, 1]))]:
 
-        self.assertAlmostEqual(val2, 0.0, 10)
+            # Compute loss values for different labels
+            val1 = loss_fn(y_true1, y_pred).numpy()  # Should be biggest (all are wrong)
+            val2 = loss_fn(y_true2, y_pred).numpy()  # Should be 0 (all are correct)
+            val3 = loss_fn(y_true3, y_pred).numpy()  # Should be in between (half are correct)
 
-        self.assertGreater(val3, val2)
-        self.assertGreater(val1, val3)
+            self.assertAlmostEqual(val2, 0.0, 10)
+
+            self.assertGreaterEqual(val3, val2)
+            self.assertGreaterEqual(val1, val3)
 
     def test_jaccard_loss(self):
         loss_fn = JaccardDistanceLoss(from_logits=False, smooth=1)
@@ -66,9 +67,25 @@ class TestFocalLoss(unittest.TestCase):
         val_4 = loss_fn(y_true, y_pred).numpy()
 
         self.assertEqual(val_1, 0.0)
-        self.assertAlmostEqual(val_2, 0.914476, 5)
-        self.assertAlmostEqual(val_3, 0.914476, 5)
-        self.assertAlmostEqual(val_4, 0.830577, 5)
+        self.assertAlmostEqual(val_2, 2.743428, 5)
+        self.assertAlmostEqual(val_3, 2.743428, 5)
+        self.assertAlmostEqual(val_4, 2.491730, 5)
+
+        loss_fn = JaccardDistanceLoss(from_logits=False, smooth=1, class_weights=np.array([0, 1, 1]))
+
+        val_1 = loss_fn(y_true, y_true).numpy()
+        val_2 = loss_fn(y_true, y_pred).numpy()
+        y_pred[..., 0] = 0
+        y_pred[..., 1] = 1
+        val_3 = loss_fn(y_true, y_pred).numpy()
+        y_pred[..., 1] = 0
+        y_pred[..., 2] = 1
+        val_4 = loss_fn(y_true, y_pred).numpy()
+
+        self.assertEqual(val_1, 0.0)
+        self.assertAlmostEqual(val_2, 1.495621, 5)
+        self.assertAlmostEqual(val_3, 1.248781, 5)
+        self.assertAlmostEqual(val_4, 1.495621, 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
NB: [PR12](https://github.com/sentinel-hub/eo-flow/pull/12) should be merged first

PR that allows users to specify weights for each class that will be multiplied with the loss function. 

This is useful to prevent `NO_DATA` labels to drive the gradient descent