### PR TITLE
Add implementation of RNN-based architectures

### DIFF
--- a/eoflow/models/__init__.py
+++ b/eoflow/models/__init__.py
@@ -1,2 +1,2 @@
 from .segmentation_unets import FCNModel, TFCNModel
-from .classification_temp_nets import TCNModel, TempCNNModel
+from .classification_temp_nets import TCNModel, TempCNNModel, BiRNN


### PR DESCRIPTION
PR to add RNN-based architectures for time-series analysis.

The type of RNN layer can be chosen from `SimpleRNN`, `GRU` or `LSTM`.