### PR TITLE
Feat/mcc

### DIFF
--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -97,11 +97,14 @@ class CroppedMetric(tf.keras.metrics.Metric):
 
 
 class MCCMetric(InitializableMetric):
-    """ Computes Mathew Correlation Coefficient metric. Wraps tf.addons.TODO to work on logits. """
+    """ Computes Mathew Correlation Coefficient metric. Wraps metrics.MatthewsCorrelationCoefficient from
+    tensorflow-addons, and reshapes the input (logits) into (m, n_classes) tensors."""
 
     def __init__(self, default_n_classes=1, name='mcc'):
-        """ Creates MeanIoU metric
+        """ Creates MCCMetric metric
 
+        :param default_n_classes: Default number of classes
+        :type default_n_classes: int
         :param name: Name of the metric
         :type name: str
         """
@@ -122,7 +125,7 @@ class MCCMetric(InitializableMetric):
     def update_state(self, y_true, y_pred, sample_weight=None):
         self.assert_initialized()
 
-        n = tf.math.reduce_prod(y_true.shape[:-1])
+        n = tf.math.reduce_prod(tf.shape(y_pred)[:-1])
         y_pred_c = tf.reshape(y_pred, (n, self.metric.num_classes))
         y_true_c = tf.reshape(y_true, (n, self.metric.num_classes))
 

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -101,7 +101,7 @@ class MCCMetric(InitializableMetric):
     tensorflow-addons, and reshapes the input (logits) into (m, n_classes) tensors. The logits are thresholded to get
     "one-hot encoded" values for (multi)class metrics """
 
-    def __init__(self, default_n_classes=1, default_threshold=0.5, name='mcc'):
+    def __init__(self, default_n_classes=2, default_threshold=0.5, name='mcc'):
         """ Creates MCCMetric metric
 
         :param default_n_classes: Default number of classes

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+import tensorflow_addons as tfa
 
 
 class InitializableMetric(tf.keras.metrics.Metric):
@@ -92,4 +93,52 @@ class CroppedMetric(tf.keras.metrics.Metric):
         return self.metric.reset_states()
 
     def get_config(self):
+        return self.metric.get_config()
+
+
+class MCCMetric(InitializableMetric):
+    """ Computes Mathew Correlation Coefficient metric. Wraps tf.addons.TODO to work on logits. """
+
+    def __init__(self, default_n_classes=1, name='mcc'):
+        """ Creates MeanIoU metric
+
+        :param name: Name of the metric
+        :type name: str
+        """
+
+        super().__init__(name=name, dtype=tf.float32)
+        self.metric = None
+        self.default_n_classes = default_n_classes
+
+    def init_from_config(self, model_config=None):
+        super().init_from_config(model_config)
+
+        if model_config is not None and 'n_classes' in model_config:
+            self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=model_config['n_classes'])
+        else:
+            print("n_classes not found in model config or model config not provided. Using default max value.")
+            self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=self.default_n_classes)
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        self.assert_initialized()
+
+        n = tf.math.reduce_prod(y_true.shape[:-1])
+        y_pred_c = tf.reshape(y_pred, (n, self.metric.num_classes))
+        y_true_c = tf.reshape(y_true, (n, self.metric.num_classes))
+
+        return self.metric.update_state(y_true_c, y_pred_c, sample_weight)
+
+    def result(self):
+        self.assert_initialized()
+
+        return self.metric.result()
+
+    def reset_states(self):
+        self.assert_initialized()
+
+        return self.metric.reset_states()
+
+    def get_config(self):
+        self.assert_initialized()
+
         return self.metric.get_config()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -138,6 +138,14 @@ class TestMCC(unittest.TestCase):
         metric.update_state(y_true, y_pred)
         self.assertAlmostEqual(metric.result().numpy()[0], -0.3333333, 7)
 
+    def test_mcc_threshold(self):
+        y_true = np.array([1, 1, 1, 0])[..., np.newaxis]
+        y_pred = np.array([0.9, 0.6, 0.61, 0.7])[..., np.newaxis]
+        metric = MCCMetric()
+        metric.init_from_config({'n_classes': 1, 'mcc_threshold': 0.6})
+        metric.update_state(y_true, y_pred)
+        self.assertAlmostEqual(metric.result().numpy()[0], -0.3333333, 7)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -110,6 +110,25 @@ class TestMCC(unittest.TestCase):
         results = metric.result().numpy()
         self.assertAlmostEqual(results[0], results[1], 7)
 
+    def test_mcc_single_vs_binary(self):
+        metric_single = MCCMetric()
+        metric_single.init_from_config({'n_classes': 1})
+
+        y_pred = np.random.randint(0, 2, (32, 32, 1))
+        y_true = np.random.randint(0, 2, (32, 32, 1))
+        metric_single.update_state(y_true, y_pred)
+        result_single = metric_single.result().numpy()[0]
+
+        metric_binary = MCCMetric()
+        metric_binary.init_from_config({'n_classes': 2})
+
+        y_pred = np.concatenate((y_pred, 1-y_pred), axis=-1)
+        y_true = np.concatenate((y_true, 1 - y_true), axis=-1)
+        metric_binary.update_state(y_true, y_pred)
+        result_binary = metric_binary.result().numpy()[0]
+
+        self.assertAlmostEqual(result_single, result_binary, 7)
+
     def test_mcc_results(self):
         # test is from an example of MCC in sklearn.metrics matthews_corrcoef
         y_true = np.array([1, 1, 1, 0])[..., np.newaxis]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,15 +1,15 @@
 import unittest
 import numpy as np
 
-from eoflow.models.metrics import MeanIoU
+from eoflow.models.metrics import MeanIoU, MCCMetric
 
 
 class TestMeanIoU(unittest.TestCase):
     def test_not_initialized(self):
         metric = MeanIoU()
 
-        y_true = np.zeros((1,32,32,3))
-        y_pred = np.zeros((1,32,32,3))
+        y_true = np.zeros((1, 32, 32, 3))
+        y_pred = np.zeros((1, 32, 32, 3))
 
         # Errors should be raised (because not initialized)
         self.assertRaises(ValueError, metric.update_state, y_true, y_pred)
@@ -33,13 +33,12 @@ class TestMeanIoU(unittest.TestCase):
         zeros = np.zeros((32, 32))
         mixed = np.concatenate([ones[:16], zeros[:16]])
 
-
         # Predict everything as class 1
         y_pred = np.stack([zeros, ones], axis=-1)
 
-        y_true1 = np.stack([ones, zeros], axis=-1) # All class 0
-        y_true2 = np.stack([zeros, ones], axis=-1) # All class 1
-        y_true3 = np.stack([mixed, 1-mixed], axis=-1) # Half class 1, half class 0
+        y_true1 = np.stack([ones, zeros], axis=-1)  # All class 0
+        y_true2 = np.stack([zeros, ones], axis=-1)  # All class 1
+        y_true3 = np.stack([mixed, 1 - mixed], axis=-1)  # Half class 1, half class 0
 
         # Check each one seperately
         metric.update_state(y_true1, y_pred)
@@ -51,14 +50,74 @@ class TestMeanIoU(unittest.TestCase):
 
         metric.reset_states()
         metric.update_state(y_true3, y_pred)
-        self.assertAlmostEqual(metric.result().numpy(), 0.25, 10) # Class 1 IoU: 0.5, Class 2 IoU: 0.0
+        self.assertAlmostEqual(metric.result().numpy(), 0.25, 10)  # Class 1 IoU: 0.5, Class 2 IoU: 0.0
 
         # Check aggregation
         metric.reset_states()
         metric.update_state(y_true1, y_pred)
         metric.update_state(y_true2, y_pred)
         metric.update_state(y_true3, y_pred)
-        self.assertAlmostEqual(metric.result().numpy(), 0.25, 10) # Class 1 IoU: 0.5, Class 2 IoU: 0.0
+        self.assertAlmostEqual(metric.result().numpy(), 0.25, 10)  # Class 1 IoU: 0.5, Class 2 IoU: 0.0
+
+
+class TestMCC(unittest.TestCase):
+    def test_not_initialized(self):
+        metric = MCCMetric()
+
+        y_true = np.zeros((1, 32, 32, 3))
+        y_pred = np.zeros((1, 32, 32, 3))
+
+        # Errors should be raised (because not initialized)
+        self.assertRaises(ValueError, metric.update_state, y_true, y_pred)
+        self.assertRaises(ValueError, metric.result)
+        self.assertRaises(ValueError, metric.reset_states)
+        self.assertRaises(ValueError, metric.get_config)
+
+        metric.init_from_config({'n_classes': 3})
+
+        # Test that errors are not raised
+        metric.update_state(y_true, y_pred)
+        metric.result()
+        metric.reset_states()
+        metric.get_config()
+
+    def test_wrong_n_classes(self):
+        metric = MCCMetric()
+
+        n_classes = 3
+        y_true = np.zeros((1, 32, 32, n_classes))
+        y_pred = np.zeros((1, 32, 32, n_classes))
+
+        metric.init_from_config({'n_classes': 1})
+
+        # Test that errors are raised
+        with self.assertRaises(Exception) as context:
+            metric.update_state(y_true, y_pred)
+            self.assertTrue((f'Input to reshape is a tensor with {np.prod(y_true.shape)} values, '
+                             f'but the requested shape has {np.prod(y_true.shape[:-1])}') in str(context.exception))
+
+    def test_mcc_results_binary_symmetry(self):
+        metric = MCCMetric()
+        metric.init_from_config({'n_classes': 2})
+
+        y_pred = np.random.randint(0, 2, (32, 32, 1))
+        y_pred = np.concatenate((y_pred, 1-y_pred), axis=-1)
+
+        y_true = np.random.randint(0, 2, (32, 32, 1))
+        y_true = np.concatenate((y_true, 1 - y_true), axis=-1)
+
+        metric.update_state(y_true, y_pred)
+        results = metric.result().numpy()
+        self.assertAlmostEqual(results[0], results[1], 7)
+
+    def test_mcc_results(self):
+        # test is from an example of MCC in sklearn.metrics matthews_corrcoef
+        y_true = np.array([1, 1, 1, 0])[..., np.newaxis]
+        y_pred = np.array([1, 0, 1, 1])[..., np.newaxis]
+        metric = MCCMetric()
+        metric.init_from_config({'n_classes': 1})
+        metric.update_state(y_true, y_pred)
+        self.assertAlmostEqual(metric.result().numpy()[0], -0.3333333, 7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a wrapper around `tensorflow-addons.metrics.MatthewsCorrelationCoefficient` so that user doesn't have to reshape logits prior to updating the metrics.

