### PR TITLE
Add a residual convolutional layer

### DIFF
--- a/eoflow/models/layers.py
+++ b/eoflow/models/layers.py
@@ -134,8 +134,8 @@ class ResidualBlock(tf.keras.layers.Layer):
 class Conv2D(tf.keras.layers.Layer):
     """ Multiple repetitions of 2d convolution, batch normalization and dropout layers. """
 
-    def __init__(self, filters, kernel_size=3, strides=1, dilation=1, padding='VALID', add_dropout=True, dropout_rate=0.2,
-                 batch_normalization=False, num_repetitions=1):
+    def __init__(self, filters, kernel_size=3, strides=1, dilation=1, padding='VALID', add_dropout=True,
+                 dropout_rate=0.2, activation='relu', batch_normalization=False, num_repetitions=1):
         super().__init__()
 
         repetitions = []
@@ -148,7 +148,7 @@ class Conv2D(tf.keras.layers.Layer):
                 strides=strides,
                 dilation_rate=dilation,
                 padding=padding,
-                activation='relu'
+                activation=activation
             ))
 
             if batch_normalization:
@@ -179,7 +179,7 @@ class ResConv2D(tf.keras.layers.Layer):
     """
 
     def __init__(self, filters, kernel_size=3, strides=1, dilation=1, padding='VALID', add_dropout=True,
-                 dropout_rate=0.2, batch_normalization=False, num_parallel=1):
+                 dropout_rate=0.2, activation='relu', batch_normalization=False, num_parallel=1):
         super().__init__()
 
         if isinstance(kernel_size, list) and len(kernel_size) != num_parallel:
@@ -196,6 +196,7 @@ class ResConv2D(tf.keras.layers.Layer):
                              strides=strides,
                              dilation=d,
                              padding=padding,
+                             activation=activation,
                              add_dropout=add_dropout,
                              dropout_rate=dropout_rate,
                              batch_normalization=batch_normalization,

--- a/eoflow/models/layers.py
+++ b/eoflow/models/layers.py
@@ -200,7 +200,7 @@ class ResConv2D(tf.keras.layers.Layer):
                              add_dropout=add_dropout,
                              dropout_rate=dropout_rate,
                              batch_normalization=batch_normalization,
-                             num_repetitions=2) for _, k, d in zip(range(num_parallel), kernel_list, dilation_list)]
+                             num_repetitions=2) for k, d in zip(kernel_list, dilation_list)]
 
         self.add = tf.keras.layers.Add()
 

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -131,7 +131,7 @@ class MCCMetric(InitializableMetric):
         else:
             print(f"Using default value for threshold: {self.threshold}.")
 
-        self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=model_config['n_classes'])
+        self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=self.default_n_classes)
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         self.assert_initialized()

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -131,7 +131,7 @@ class MCCMetric(InitializableMetric):
         else:
             print(f"Using default value for threshold: {self.threshold}.")
 
-        self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=self.default_n_classes)
+        self.metric = tfa.metrics.MatthewsCorrelationCoefficient(num_classes=model_config['n_classes'])
 
     def update_state(self, y_true, y_pred, sample_weight=None):
         self.assert_initialized()

--- a/eoflow/models/metrics.py
+++ b/eoflow/models/metrics.py
@@ -140,7 +140,7 @@ class MCCMetric(InitializableMetric):
         y_pred_c = tf.reshape(y_pred > self.threshold, (n, self.metric.num_classes))
         y_true_c = tf.reshape(y_true, (n, self.metric.num_classes))
 
-        return self.metric.update_state(y_true_c, y_pred_c, sample_weight)
+        return self.metric.update_state(y_true_c, y_pred_c, sample_weight=sample_weight)
 
     def result(self):
         self.assert_initialized()

--- a/eoflow/models/segmentation_base.py
+++ b/eoflow/models/segmentation_base.py
@@ -8,8 +8,9 @@ from marshmallow.validate import OneOf, ContainsOnly
 
 from ..base import BaseModel
 
-from .losses import CategoricalCrossEntropy, CategoricalFocalLoss, JaccardDistanceLoss, cropped_loss
-from .metrics import MeanIoU, InitializableMetric, CroppedMetric
+from .losses import CategoricalCrossEntropy, CategoricalFocalLoss, JaccardDistanceLoss, TanimotoDistanceLoss
+from .losses import cropped_loss
+from .metrics import MeanIoU, InitializableMetric, CroppedMetric, MCCMetric
 from .callbacks import VisualizationCallback
 
 logging.basicConfig(level=logging.INFO,
@@ -20,7 +21,8 @@ logging.basicConfig(level=logging.INFO,
 segmentation_losses = {
     'cross_entropy': CategoricalCrossEntropy,
     'focal_loss': CategoricalFocalLoss,
-    'jaccard_loss': JaccardDistanceLoss
+    'jaccard_loss': JaccardDistanceLoss,
+    'tanimoto_loss': TanimotoDistanceLoss
 }
 
 
@@ -29,7 +31,8 @@ segmentation_metrics = {
     'accuracy': lambda: tf.keras.metrics.CategoricalAccuracy(name='accuracy'),
     'iou': lambda: MeanIoU(default_max_classes=32),
     'precision': tf.keras.metrics.Precision,
-    'recall': tf.keras.metrics.Recall
+    'recall': tf.keras.metrics.Recall,
+    'mcc': MCCMetric
 }
 
 

--- a/eoflow/models/segmentation_base.py
+++ b/eoflow/models/segmentation_base.py
@@ -32,7 +32,7 @@ segmentation_metrics = {
     'iou': lambda: MeanIoU(default_max_classes=32),
     'precision': tf.keras.metrics.Precision,
     'recall': tf.keras.metrics.Recall,
-    'mcc': lambda: MCCMetric()
+    'mcc': MCCMetric
 }
 
 

--- a/eoflow/models/segmentation_base.py
+++ b/eoflow/models/segmentation_base.py
@@ -32,7 +32,7 @@ segmentation_metrics = {
     'iou': lambda: MeanIoU(default_max_classes=32),
     'precision': tf.keras.metrics.Precision,
     'recall': tf.keras.metrics.Recall,
-    'mcc': MCCMetric
+    'mcc': lambda: MCCMetric()
 }
 
 

--- a/eoflow/models/segmentation_unets.py
+++ b/eoflow/models/segmentation_unets.py
@@ -20,6 +20,7 @@ class FCNModel(BaseSegmentationModel):
         conv_size = fields.Int(missing=3, description='Size of the convolution kernels.')
         deconv_size = fields.Int(missing=2, description='Size of the deconvolution kernels.')
         conv_stride = fields.Int(missing=1, description='Stride used in convolutions.')
+        dilation_rate = fields.Int(missing=1, description='Dilation rate used in convolutions.')
         add_dropout = fields.Bool(missing=False, description='Add dropout to layers.')
         add_batch_norm = fields.Bool(missing=True, description='Add batch normalization to layers.')
         bias_init = fields.Float(missing=0.0, description='Bias initialization value.')
@@ -51,6 +52,7 @@ class FCNModel(BaseSegmentationModel):
                 filters=features,
                 kernel_size=self.config.conv_size,
                 strides=self.config.conv_stride,
+                dilation=self.config.dilation_rate,
                 add_dropout=self.config.add_dropout,
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,
@@ -70,6 +72,7 @@ class FCNModel(BaseSegmentationModel):
             filters=2 ** self.config.n_layers * self.config.features_root,
             kernel_size=self.config.conv_size,
             strides=self.config.conv_stride,
+            dilation=self.config.dilation_rate,
             add_dropout=self.config.add_dropout,
             dropout_rate=dropout_rate,
             batch_normalization=self.config.add_batch_norm,
@@ -85,13 +88,6 @@ class FCNModel(BaseSegmentationModel):
             # get same number of features as counterpart layer
             features = 2 ** conterpart_layer * self.config.features_root
 
-            # transposed convolution to upsample tensors
-            # shape = net.get_shape().as_list()
-            # deconv_output_shape = [tf.shape(net)[0],
-            #                        shape[1] * self.config.deconv_size,
-            #                        shape[2] * self.config.deconv_size,
-            #                        features]
-
             deconv = Deconv2D(
                 filters=features,
                 kernel_size=self.config.deconv_size,
@@ -106,6 +102,7 @@ class FCNModel(BaseSegmentationModel):
                 filters=features,
                 kernel_size=self.config.conv_size,
                 strides=self.config.conv_stride,
+                dilation=self.config.dilation_rate,
                 add_dropout=self.config.add_dropout,
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,

--- a/eoflow/models/segmentation_unets.py
+++ b/eoflow/models/segmentation_unets.py
@@ -20,7 +20,7 @@ class FCNModel(BaseSegmentationModel):
         conv_size = fields.Int(missing=3, description='Size of the convolution kernels.')
         deconv_size = fields.Int(missing=2, description='Size of the deconvolution kernels.')
         conv_stride = fields.Int(missing=1, description='Stride used in convolutions.')
-        dilation_rate = fields.Int(missing=1, description='Dilation rate used in convolutions.')
+        dilation_rate = fields.List(fields.Int, missing=1, description='Dilation rate used in convolutions.')
         add_dropout = fields.Bool(missing=False, description='Add dropout to layers.')
         add_batch_norm = fields.Bool(missing=True, description='Add batch normalization to layers.')
         bias_init = fields.Float(missing=0.0, description='Bias initialization value.')

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,29 @@
+import unittest
+
+import tensorflow as tf
+from eoflow.models.layers import ResConv2D
+
+
+class TestLayers(unittest.TestCase):
+    def test_res_conv_layer(self):
+        input_shape = (4, 28, 28, 3)
+
+        x = tf.ones(input_shape)
+
+        for npar in range(1, 4):
+            y = ResConv2D(3, kernel_size=[npar]*npar, num_parallel=npar, padding='SAME')(x)
+            self.assertEqual(y.shape, input_shape)
+
+            y = ResConv2D(3, kernel_size=[npar]*npar, dilation=[npar]*npar, num_parallel=npar, padding='SAME')(x)
+            self.assertEqual(y.shape, input_shape)
+
+            y = ResConv2D(3, dilation=[npar]*npar, num_parallel=npar, padding='SAME')(x)
+            self.assertEqual(y.shape, input_shape)
+
+        with self.assertRaises(ValueError):
+            ResConv2D(filters=3, kernel_size=[3, 3], padding='SAME', num_parallel=3)
+            ResConv2D(filters=3, dilation=[3, 3], padding='SAME', num_parallel=3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a residual convolutional block, as described in the following figure.

![res-conv-2d-diagram](https://user-images.githubusercontent.com/14233816/85136671-409e7900-b240-11ea-9f24-30c22bbe392a.png)

Batch normalisation is optional. Different values for `kernel_size` and `dilation` can be provided for each convolutional block.