### PR TITLE
Add Pyramid Pooling Module layer

### DIFF
--- a/eoflow/models/layers.py
+++ b/eoflow/models/layers.py
@@ -376,6 +376,8 @@ class PyramidPoolingModule(tf.keras.layers.Layer):
                 layer.add(BatchNormalization())
             layer.add(Activation('relu'))
 
+            layer.add(UpSampling2D(size=(height//bin_size, width//bin_size), interpolation=self.interpolation))
+
             layers.append(layer)
 
         self.layers = layers
@@ -386,8 +388,6 @@ class PyramidPoolingModule(tf.keras.layers.Layer):
 
         outputs = list([inputs])
 
-        for layer, bin_size in zip(self.layers, self.bins):
-            upsample = UpSampling2D(size=(height//bin_size, width//bin_size), interpolation=self.interpolation)
-            outputs.append(upsample(layer(inputs, training=training)))
+        outputs += [layer(inputs, training=training) for layer in self.layers]
 
         return tf.concat(outputs, axis=-1)

--- a/eoflow/models/layers.py
+++ b/eoflow/models/layers.py
@@ -365,8 +365,11 @@ class PyramidPoolingModule(tf.keras.layers.Layer):
         layers = []
 
         for bin_size in self.bins:
+
+            size_factors = height // bin_size, width // bin_size
+
             layer = tf.keras.Sequential()
-            layer.add(AveragePooling2D(pool_size=(height//bin_size, width//bin_size),
+            layer.add(AveragePooling2D(pool_size=size_factors,
                                        padding='same'))
             layer.add(tf.keras.layers.Conv2D(filters=self.filters//len(self.bins),
                                              kernel_size=1,
@@ -376,7 +379,7 @@ class PyramidPoolingModule(tf.keras.layers.Layer):
                 layer.add(BatchNormalization())
             layer.add(Activation('relu'))
 
-            layer.add(UpSampling2D(size=(height//bin_size, width//bin_size), interpolation=self.interpolation))
+            layer.add(UpSampling2D(size=size_factors, interpolation=self.interpolation))
 
             layers.append(layer)
 
@@ -386,7 +389,7 @@ class PyramidPoolingModule(tf.keras.layers.Layer):
         """ Concatenate the output of the pooling layers, resampled to original size """
         _, height, width, _ = inputs.shape
 
-        outputs = list([inputs])
+        outputs = [inputs]
 
         outputs += [layer(inputs, training=training) for layer in self.layers]
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,7 +1,8 @@
 import unittest
 
+import numpy as np
 import tensorflow as tf
-from eoflow.models.layers import ResConv2D
+from eoflow.models.layers import ResConv2D, PyramidPoolingModule
 
 
 class TestLayers(unittest.TestCase):
@@ -23,6 +24,23 @@ class TestLayers(unittest.TestCase):
         with self.assertRaises(ValueError):
             ResConv2D(filters=3, kernel_size=[3, 3], padding='SAME', num_parallel=3)
             ResConv2D(filters=3, dilation=[3, 3], padding='SAME', num_parallel=3)
+
+    def test_ppm_layer(self):
+        batch_size, height, width, nchannels = 1, 64, 64, 1
+        input_shape = (batch_size, height, width, nchannels)
+        filters = 4
+        bins = (1, 2, 4, 8)
+
+        x = np.arange(np.prod(input_shape)).reshape(input_shape).astype(np.float32)
+
+        ppm = PyramidPoolingModule(filters=filters, bins=bins, interpolation='nearest')
+
+        y = ppm(x)
+
+        self.assertEqual(y.shape, (batch_size, height, width, filters+nchannels))
+        np.testing.assert_array_equal(y[..., 0], x[..., 0])
+        for nbin, bin_size in enumerate(bins):
+            self.assertLessEqual(np.unique(y[..., nbin+1]).size, bin_size**2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement a Pyramid Pooling Module layer, as described in [this paper](https://arxiv.org/pdf/1612.01105.pdf).

Corresponding PyTorch implementation can be found [here](https://github.com/hszhao/semseg/blob/master/model/pspnet.py).

![pyramid-pooling-module-diagram](https://user-images.githubusercontent.com/14233816/86140640-5be76f00-baf1-11ea-9419-f9034913b5ab.png)

#30 is included here and should be merged first