### PR TITLE
Expose use_bias parameter in conv2d and conv3d layers

### DIFF
--- a/eoflow/models/layers.py
+++ b/eoflow/models/layers.py
@@ -135,7 +135,7 @@ class Conv2D(tf.keras.layers.Layer):
     """ Multiple repetitions of 2d convolution, batch normalization and dropout layers. """
 
     def __init__(self, filters, kernel_size=3, strides=1, dilation=1, padding='VALID', add_dropout=True,
-                 dropout_rate=0.2, activation='relu', batch_normalization=False, num_repetitions=1):
+                 dropout_rate=0.2, activation='relu', batch_normalization=False, use_bias=True, num_repetitions=1):
         super().__init__()
 
         repetitions = []
@@ -148,6 +148,7 @@ class Conv2D(tf.keras.layers.Layer):
                 strides=strides,
                 dilation_rate=dilation,
                 padding=padding,
+                use_bias=use_bias,
                 activation=activation
             ))
 
@@ -179,7 +180,7 @@ class ResConv2D(tf.keras.layers.Layer):
     """
 
     def __init__(self, filters, kernel_size=3, strides=1, dilation=1, padding='VALID', add_dropout=True,
-                 dropout_rate=0.2, activation='relu', batch_normalization=False, num_parallel=1):
+                 dropout_rate=0.2, activation='relu', use_bias=True, batch_normalization=False, num_parallel=1):
         super().__init__()
 
         if isinstance(kernel_size, list) and len(kernel_size) != num_parallel:
@@ -199,6 +200,7 @@ class ResConv2D(tf.keras.layers.Layer):
                              activation=activation,
                              add_dropout=add_dropout,
                              dropout_rate=dropout_rate,
+                             use_bias=use_bias,
                              batch_normalization=batch_normalization,
                              num_repetitions=2) for k, d in zip(kernel_list, dilation_list)]
 
@@ -214,7 +216,7 @@ class Conv3D(tf.keras.layers.Layer):
     """ Multiple repetitions of 3d convolution, batch normalization and dropout layers. """
 
     def __init__(self, filters, kernel_size=3, strides=1, padding='VALID', add_dropout=True, dropout_rate=0.2,
-                 batch_normalization=False, num_repetitions=1, convolve_time=True):
+                 batch_normalization=False, use_bias=True, num_repetitions=1, convolve_time=True):
         super().__init__()
 
         repetitions = []
@@ -229,6 +231,7 @@ class Conv3D(tf.keras.layers.Layer):
                 kernel_size=kernel_shape,
                 strides=strides,
                 padding=padding,
+                use_bias=use_bias,
                 activation='relu'
             ))
 

--- a/eoflow/models/segmentation_unets.py
+++ b/eoflow/models/segmentation_unets.py
@@ -24,6 +24,7 @@ class FCNModel(BaseSegmentationModel):
         add_dropout = fields.Bool(missing=False, description='Add dropout to layers.')
         add_batch_norm = fields.Bool(missing=True, description='Add batch normalization to layers.')
         bias_init = fields.Float(missing=0.0, description='Bias initialization value.')
+        use_bias = fields.Bool(missing=True, description='Add bias parameters to convolutional layer.')
         padding = fields.String(missing='VALID', description='Padding type used in convolutions.')
 
         pool_size = fields.Int(missing=2, description='Kernel size used in max pooling.')
@@ -57,6 +58,7 @@ class FCNModel(BaseSegmentationModel):
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,
                 padding=self.config.padding,
+                use_bias=self.config.use_bias,
                 num_repetitions=2)(net)
 
             connection_outputs.append(conv)
@@ -76,6 +78,7 @@ class FCNModel(BaseSegmentationModel):
             add_dropout=self.config.add_dropout,
             dropout_rate=dropout_rate,
             batch_normalization=self.config.add_batch_norm,
+            use_bias=self.config.use_bias,
             num_repetitions=2,
             padding=self.config.padding)(net)
 
@@ -106,6 +109,7 @@ class FCNModel(BaseSegmentationModel):
                 add_dropout=self.config.add_dropout,
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,
+                use_bias=self.config.use_bias,
                 num_repetitions=2,
                 padding=self.config.padding)(cc)
 
@@ -137,6 +141,7 @@ class TFCNModel(BaseSegmentationModel):
         add_dropout = fields.Bool(missing=False, description='Add dropout to layers.')
         add_batch_norm = fields.Bool(missing=True, description='Add batch normalization to layers.')
         bias_init = fields.Float(missing=0.0, description='Bias initialization value.')
+        use_bias = fields.Bool(missing=True, description='Add bias parameters to convolutional layer.')
         padding = fields.String(missing='VALID', description='Padding type used in convolutions.')
         single_encoding_conv = fields.Bool(missing=False, description="Whether to apply 1 or 2 banks of conv filters.")
 
@@ -168,6 +173,7 @@ class TFCNModel(BaseSegmentationModel):
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,
                 num_repetitions=num_repetitions,
+                use_bias=self.config.use_bias,
                 padding=self.config.padding)(net)
 
             connection_outputs.append(conv)
@@ -187,6 +193,7 @@ class TFCNModel(BaseSegmentationModel):
             batch_normalization=self.config.add_batch_norm,
             num_repetitions=num_repetitions,
             padding=self.config.padding,
+            use_bias=self.config.use_bias,
             convolve_time=(not self.config.pool_time))(net)
 
         # Reduce temporal dimension
@@ -231,6 +238,7 @@ class TFCNModel(BaseSegmentationModel):
                 dropout_rate=dropout_rate,
                 batch_normalization=self.config.add_batch_norm,
                 padding=self.config.padding,
+                use_bias=self.config.use_bias,
                 num_repetitions=2)(cc)
 
         # final 1x1 convolution corresponding to pixel-wise linear combination of feature channels


### PR DESCRIPTION
In deep convolutional networks, the bias parameters might have little influence on the learned features. Exposing the `use_bias` parameter allows to remove biases from convolutional layers, therefore slightly reducing the overall number of parameters.