### PR TITLE
Feat/same padding reduce3d to2 d

### DIFF
--- a/eoflow/models/segmentation_unets.py
+++ b/eoflow/models/segmentation_unets.py
@@ -202,7 +202,8 @@ class TFCNModel(BaseSegmentationModel):
             kernel_size=self.config.conv_size_reduce,
             stride=self.config.conv_stride,
             add_dropout=self.config.add_dropout,
-            dropout_rate=dropout_rate)(bottom)
+            dropout_rate=dropout_rate,
+            padding=self.config.padding)(bottom)
 
         net = bottom
         # decoding path
@@ -224,7 +225,8 @@ class TFCNModel(BaseSegmentationModel):
                 kernel_size=self.config.conv_size_reduce,
                 stride=self.config.conv_stride,
                 add_dropout=self.config.add_dropout,
-                dropout_rate=dropout_rate)(connection_outputs[conterpart_layer])
+                dropout_rate=dropout_rate,
+                padding=self.config.padding)(connection_outputs[conterpart_layer])
 
             # crop and concatenate
             cc = CropAndConcat()(reduced, deconv)


### PR DESCRIPTION
Using 'SAME' padding as suggested here: https://github.com/sentinel-hub/eo-flow/issues/35
would still not lead to a TFCN model with identical input and output spatial dimension sizes because the Reduce3DTo2D layer was hard coded with 'VALID' padding.

This branch passes the TFCN model config padding parameter also to the Reduce3DTo2D layer, and enables 'SAME' padding within that layer's build method.
As using padding='SAME' in the contained Conv3D layer would lead to padding of the temporal dimension (which is what the layer is intended to reduce and squeeze), the spatial dimensions are padded separately.